### PR TITLE
Explicitly set shebang to python2 via /usr/bin/env

### DIFF
--- a/bin/opensnitch
+++ b/bin/opensnitch
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # This file is part of OpenSnitch.
 #
 # Copyright(c) 2017 Simone Margaritelli
@@ -61,5 +61,3 @@ def main():
     snitch.stop()
 
 main()
-
-


### PR DESCRIPTION
Fixes running on systems where python is not in /usr/bin (such as in the case of virtualenvs, nixos) or when /usr/bin/python is python3