### PR TITLE
added parenthesis around except arguments

### DIFF
--- a/opensnitch/dns.py
+++ b/opensnitch/dns.py
@@ -54,7 +54,7 @@ class DNSCollector:
 
                         logging.debug( "Adding DNS response: %s => %s" % ( address, hostname ) )
                         self.hosts[address] = hostname
-                except Exception, e:
+                except (Exception, e):
                     logging.debug("Error while parsing DNS response: %s" % e)
 
     def get_hostname( self, address ):

--- a/opensnitch/snitch.py
+++ b/opensnitch/snitch.py
@@ -81,7 +81,7 @@ class Snitch:
                 else:
                     verd = self.get_verdict( conn )
 
-        except Exception, e:
+        except (Exception, e):
             logging.exception( "Exception on packet callback:" )
 
         if verd == Rule.DROP:


### PR DESCRIPTION
Hello Simone, I was trying to make a RPM package of opensnitch, and I got some syntax errors messages

```
Bytecompiling .py files below /builddir/build/BUILDROOT/python-opensnitch-0.0.2-1.fc25.x86_64/usr/lib/python3.5 using /usr/bin/python3.5
*** Error compiling '/builddir/build/BUILDROOT/python-opensnitch-0.0.2-1.fc25.x86_64/usr/lib/python3.5/site-packages/opensnitch/dns.py'...
  File "/usr/lib/python3.5/dns.py", line 57
    except Exception, e:
                    ^
SyntaxError: invalid syntax

*** Error compiling '/builddir/build/BUILDROOT/python-opensnitch-0.0.2-1.fc25.x86_64/usr/lib/python3.5/site-packages/opensnitch/snitch.py'...
  File "/usr/lib/python3.5/snitch.py", line 84
    except Exception, e:
                    ^
SyntaxError: invalid syntax
```

Then I made the following changes and now rpmbuild no longer complains.
Have a nice day