### PR TITLE
Use iptables trough iptc, enables rootless operation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 from setuptools import setup, find_packages
 from opensnitch.version import VERSION
-import os
 
 try:
   long_description = open( 'README.md', 'rt' ).read()
@@ -37,5 +36,9 @@ setup( name                 = 'opensnitch',
        package_data         = {'': ['*.ui']},
        license              = 'GPL',
        zip_safe             = False,
-       install_requires     = [ 'scapy', 'dpkt', 'NetfilterQueue', 'psutil' ]
+       install_requires     = ['scapy',
+                               'dpkt',
+                               'NetfilterQueue',
+                               'psutil',
+                               'python-iptables']
 )


### PR DESCRIPTION
Related to #38 

Provided I do `setcap 'cap_net_raw,cap_dac_override,cap_net_admin=+ep' $(which python2)` I can run opensnitch with an unprivileged user.

Needed `cap_net_raw` because of how communication with the kernel happens from iptables.

I say we still keep #38 open though, this is a larger issue