### PR TITLE
Use iptables trough iptc, enables rootless operation

### DIFF
--- a/opensnitch/__main__.py
+++ b/opensnitch/__main__.py
@@ -22,7 +22,6 @@ from os.path import expanduser
 import warnings
 import logging
 import os
-import sys
 
 from opensnitch.version import VERSION
 from opensnitch.snitch import Snitch
@@ -44,9 +43,6 @@ parser.add_argument("--database",  dest="database", default=filename,
                     help="Database path.", metavar="FILE")
 
 args = parser.parse_args()
-
-if not os.geteuid() == 0:
-    sys.exit('OpenSnitch must be run as root.')
 
 
 # Ensure Qt4 wont be loaded by matplotlib

--- a/opensnitch/iptables.py
+++ b/opensnitch/iptables.py
@@ -1,0 +1,74 @@
+import iptc
+
+
+class IPTCRules:
+
+    def __init__(self):
+        self.tables = {
+            iptc.Table.FILTER: iptc.Table(iptc.Table.FILTER),
+            iptc.Table.MANGLE: iptc.Table(iptc.Table.MANGLE),
+        }
+        for t in self.tables.values():
+            t.autocommit = False
+
+        self.chains = {
+            c: r for c, r in (
+                self.insert_dns_rule(),
+                self.insert_connection_packet_rules(),
+                self.insert_reject_rule())
+        }
+
+        self.commit()
+
+    def commit(self):
+        for t in self.tables.values():
+            t.commit()
+            t.refresh()
+
+    def remove(self):
+        for c, r in self.chains.items():
+            c.delete_rule(r)
+
+        self.commit()
+
+    def insert_dns_rule(self):
+        """Get DNS responses"""
+        chain = iptc.Chain(self.tables[iptc.Table.FILTER], 'INPUT')
+        rule = iptc.Rule()
+        rule.protocol = 'udp'
+        m = rule.create_match('udp')
+        m.sport = '53'
+
+        t = rule.create_target('NFQUEUE')
+        t.set_parameter('queue-num', str(0))
+        t.set_parameter('queue-bypass')
+
+        chain.insert_rule(rule)
+        return (chain, rule)
+
+    def insert_connection_packet_rules(self):
+        chain = iptc.Chain(self.tables[iptc.Table.MANGLE], 'OUTPUT')
+        rule = iptc.Rule()
+
+        t = rule.create_target('NFQUEUE')
+        t.set_parameter('queue-num', str(0))
+        t.set_parameter('queue-bypass')
+
+        m = rule.create_match('conntrack')
+        m.set_parameter('ctstate', 'NEW')
+
+        chain.insert_rule(rule)
+        return (chain, rule)
+
+    def insert_reject_rule(self):
+        chain = iptc.Chain(self.tables[iptc.Table.FILTER], 'OUTPUT')
+        rule = iptc.Rule()
+        rule.protol = 'tcp'
+
+        rule.create_target('REJECT')
+
+        m = rule.create_match('mark')
+        m.mark = '0x18ba5'
+
+        chain.insert_rule(rule)
+        return (chain, rule)

--- a/setup.py
+++ b/setup.py
@@ -49,4 +49,6 @@ setup(name='opensnitch',
           'dpkt',
           'NetfilterQueue',
           'psutil',
-          'pyinotify'])
+          'pyinotify',
+          'python-iptables'
+      ])


### PR DESCRIPTION
Reviving my PR https://github.com/evilsocket/opensnitch/pull/41 and
polishing it up a bit for easier usage.

The wrapper script makes running without root as easy as `sudo opensnitch` and that will check  the SUDO_USER environment variable by default or the argument `--user`

Why this is needed:
I was working on getting D-bus based IPC working and wanted to do my dev work using the D-Bus Session Bus (the one running in my desktop session).
Running something in my users session bus is very tricky from the root account and not something I feel comfortable expecting from users even at this point.
Using the System Bus is also out of the question for now since it needs to be provided by a .service file on systemd based distros (which is great for us since it solves the issue of some malware impersonating opensnitch).
I want us to transition to using the System Bus in the future but Session Bus is easier for now.