### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You'll need a GNU/Linux distribution with `iptables`, `NFQUEUE` and `ftrace` ker
 
 ## Install
 
-    sudo apt-get install build-essential python3-dev python3-setuptools libnetfilter-queue-dev python3-pyqt5 python3-gobject
+    sudo apt-get install build-essential python3-dev python3-setuptools libnetfilter-queue-dev python3-pyqt5 python3-gobject libcap-dev
     cd opensnitch
     sudo python3 setup.py install
 


### PR DESCRIPTION
On my ubuntu 16.04 I had to install libcap-dev otherwise I get the message : 
```
Running python-prctl-1.6.1/setup.py -q bdist_egg --dist-dir /tmp/easy_install-akxp66iq/python-prctl-1.6.1/egg-dist-tmp-ckm7a3jz
You need to install libcap development headers to build this module
error: Setup script exited with 1
```