### PR TITLE
I created a tl;dr for installing opensnitch on Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,24 @@
   <img src="https://raw.githubusercontent.com/evilsocket/opensnitch/master/screenshot.png" alt="OpenSnitch"/>
 </p>
 
-### TL;DR
+### TL;DR - Debian/Ubuntu
 
     sudo apt-get install golang protobuf-compiler libpcap-dev libnetfilter-queue-dev
+    python3 -m pip install --user grpcio-tools
+    go get github.com/golang/protobuf/protoc-gen-go
+    go get -u github.com/golang/dep/cmd/dep
+    cd /path/to/this/repo
+    make
+    sudo make install
+
+    sudo systemctl enable opensnitchd
+    sudo service opensnitchd start
+    opensnitch-ui
+    
+### TL;DR - Fedora
+
+    sudo dnf install golang protobuf-compiler libpcap-devel libnetfilter_queue-devel
+    python3 -m pip install --user --upgrade pip
     python3 -m pip install --user grpcio-tools
     go get github.com/golang/protobuf/protoc-gen-go
     go get -u github.com/golang/dep/cmd/dep

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@
 
     sudo apt-get install golang protobuf-compiler libpcap-dev libnetfilter-queue-dev
     python3 -m pip install --user grpcio-tools
-    
+    go get github.com/golang/protobuf/protoc-gen-go
+    go get -u github.com/golang/dep/cmd/dep
     cd /path/to/this/repo
     make
     sudo make install
@@ -29,8 +30,9 @@
 ### TL;DR - Fedora
 
     sudo dnf install golang protobuf-compiler libpcap-devel libnetfilter_queue-devel python3-lxml godep 
-    go get github.com/golang/protobuf/protoc-gen-go
-    go get -u github.com/golang/dep/cmd/dep
+    python3 -m pip install --upgrade pip
+    python3 -m pip install --user grpcio-tools
+    go get github.com/golang/protobuf/protoc-gen-go #until bug [1567650](https://bugzilla.redhat.com/show_bug.cgi?id=1567650) is fixed, then just install package golang-googlecode-goprotobuf
     git clone https://github.com/evilsocket/opensnitch.git
     cd opensnitch
     make

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@
 
     sudo apt-get install golang protobuf-compiler libpcap-dev libnetfilter-queue-dev
     python3 -m pip install --user grpcio-tools
-    go get github.com/golang/protobuf/protoc-gen-go
-    go get -u github.com/golang/dep/cmd/dep
+    
     cd /path/to/this/repo
     make
     sudo make install
@@ -29,12 +28,11 @@
     
 ### TL;DR - Fedora
 
-    sudo dnf install golang protobuf-compiler libpcap-devel libnetfilter_queue-devel
-    python3 -m pip install --user --upgrade pip
-    python3 -m pip install --user grpcio-tools
+    sudo dnf install golang protobuf-compiler libpcap-devel libnetfilter_queue-devel python3-lxml godep 
     go get github.com/golang/protobuf/protoc-gen-go
     go get -u github.com/golang/dep/cmd/dep
-    cd /path/to/this/repo
+    git clone https://github.com/evilsocket/opensnitch.git
+    cd opensnitch
     make
     sudo make install
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@
     
 ### TL;DR - Fedora
 
-    sudo dnf install golang protobuf-compiler libpcap-devel libnetfilter_queue-devel python3-lxml godep 
-    python3 -m pip install --upgrade pip
-    python3 -m pip install --user grpcio-tools
-    go get github.com/golang/protobuf/protoc-gen-go [1]
+    sudo dnf install golang protobuf-compiler libpcap-devel libnetfilter_queue-devel
+    go get github.com/golang/protobuf/protoc-gen-go
+    go get -u github.com/golang/dep/cmd/dep
+    cd $HOME/go/src
     git clone https://github.com/evilsocket/opensnitch.git
     cd opensnitch
     make
@@ -41,8 +41,6 @@
     sudo systemctl enable opensnitchd
     sudo service opensnitchd start
     opensnitch-ui
-
-[1] until bug [1567650](https://bugzilla.redhat.com/show_bug.cgi?id=1567650) is fixed, then just install package golang-googlecode-goprotobuf
 
 ### Daemon
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
     sudo dnf install golang protobuf-compiler libpcap-devel libnetfilter_queue-devel python3-lxml godep 
     python3 -m pip install --upgrade pip
     python3 -m pip install --user grpcio-tools
-    go get github.com/golang/protobuf/protoc-gen-go #until bug [1567650](https://bugzilla.redhat.com/show_bug.cgi?id=1567650) is fixed, then just install package golang-googlecode-goprotobuf
+    go get github.com/golang/protobuf/protoc-gen-go [1]
     git clone https://github.com/evilsocket/opensnitch.git
     cd opensnitch
     make
@@ -41,6 +41,8 @@
     sudo systemctl enable opensnitchd
     sudo service opensnitchd start
     opensnitch-ui
+
+[1] until bug [1567650](https://bugzilla.redhat.com/show_bug.cgi?id=1567650) is fixed, then just install package golang-googlecode-goprotobuf
 
 ### Daemon
 


### PR DESCRIPTION
Here is what I learned:
Tried to shift protoc-gen-go and godep to versions directly from fedora repos.
Discovered protoc-gen-go and protobug-compiler packages clashed, filed bug https://bugzilla.redhat.com/show_bug.cgi?id=1567650
Also discovered python3-pip package needed to be updated in repos, filed bug https://bugzilla.redhat.com/show_bug.cgi?id=1567652
Figured out had had to put project in $HOME/go/src, see golang/dep#148
No need to install anything via pip ahead of time, now the specific packages needed are all installed via requirements.txt.