### PR TITLE
Fix #140 : Include python3-pip and grpcio-tools in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ Make sure you have a correctly configured **Go >= 1.8** environment, that the `$
 
 ```bash
 # install dependencies
-sudo apt-get install protobuf-compiler libpcap-dev libnetfilter-queue-dev
+sudo apt-get install protobuf-compiler libpcap-dev libnetfilter-queue-dev python3-pip
 go get github.com/golang/protobuf/protoc-gen-go
 go get -u github.com/golang/dep/cmd/dep
+python3 -m pip install --user grpcio-tools
 # clone the repository (ignore the message about no Go files being found)
 go get github.com/evilsocket/opensnitch
 cd $GOPATH/src/github.com/evilsocket/opensnitch


### PR DESCRIPTION
Installation requires python3-pip and pip installed grpcio-tools to complete successfully.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>