### PR TITLE
Update probed function sys_execve to do_execve

### DIFF
--- a/daemon/conman/connection.go
+++ b/daemon/conman/connection.go
@@ -71,7 +71,7 @@ func NewConnection(nfp *netfilter.Packet, ip *layers.IPv4) (c *Connection, err e
 	c = &Connection{
 		SrcIP:   ip.SrcIP,
 		DstIP:   ip.DstIP,
-		DstHost: dns.HostOr(ip.DstIP, ""),
+		DstHost: dns.HostOr(ip.DstIP, ip.DstIP.String()),
 		pkt:     nfp,
 	}
 

--- a/daemon/dns/track.go
+++ b/daemon/dns/track.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	responses = make(map[string]string, 0)
-	lock      = sync.Mutex{}
+	lock      = sync.RWMutex{}
 )
 
 func TrackAnswers(packet gopacket.Packet) bool {
@@ -63,8 +63,8 @@ func Track(resolved string, hostname string) {
 }
 
 func Host(resolved string) (host string, found bool) {
-	lock.Lock()
-	defer lock.Unlock()
+	lock.RLock()
+	defer lock.RUnlock()
 
 	host, found = responses[resolved]
 	return

--- a/daemon/firewall/rules.go
+++ b/daemon/firewall/rules.go
@@ -32,6 +32,27 @@ func RunRule(enable bool, rule []string) (err error) {
 
 // INPUT --protocol udp --sport 53 -j NFQUEUE --queue-num 0 --queue-bypass
 func QueueDNSResponses(enable bool, queueNum int) (err error) {
+	// If enable, we're going to insert as #1, not append
+	if enable {
+		// FIXME: this is basically copy/paste of RunRule() above b/c we can't
+		// shoehorn "-I" with the boolean 'enable' switch
+		rule := []string{
+			"-I",
+			"INPUT",
+			"1",
+			"--protocol", "udp",
+			"--sport", "53",
+			"-j", "NFQUEUE",
+			"--queue-num", fmt.Sprintf("%d", queueNum),
+			"--queue-bypass",
+		}
+		lock.Lock()
+		defer lock.Unlock()
+		_, err := core.Exec("iptables", rule)
+		return err
+	}
+
+	// Otherwise, it's going to be disable
 	return RunRule(enable, []string{
 		"INPUT",
 		"--protocol", "udp",

--- a/daemon/procmon/watcher.go
+++ b/daemon/procmon/watcher.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	probeName   = "opensnitch_exec_probe"
-	syscallName = "sys_execve"
+	syscallName = "do_execve"
 )
 
 type procData struct {

--- a/ui/opensnitch/dialogs/stats.py
+++ b/ui/opensnitch/dialogs/stats.py
@@ -201,7 +201,12 @@ class StatsDialog(QtWidgets.QDialog, uic.loadUiType(DIALOG_UI_PATH)[0]):
             by_users = {}
             if self._address is None:
                 for uid, hits in self._stats.by_uid.items():
-                    by_users["%s (%s)" % (pwd.getpwuid(int(uid)).pw_name, uid)] = hits
+                    try:
+                        pw_name = pwd.getpwall(int(uid)).pw_name
+                    except KeyError:
+                        pw_name = "(UID error)"
+                    finally:
+                        by_users["%s (%s)" % (pw_name, uid)] = hits
             else:
                 by_users = self._stats.by_uid
 


### PR DESCRIPTION
This is to address #184: https://github.com/evilsocket/opensnitch/issues/184

`sys_execve` does not appear to be an available filter function:

```
# grep execve /sys/kernel/debug/tracing/available_filter_functions 
audit_log_execve_info
do_execveat_common.isra.37
__ia32_compat_sys_execve
__ia32_compat_sys_execveat
__ia32_sys_execve
__ia32_sys_execveat
__x64_sys_execve
__x64_sys_execveat
do_execve
do_execveat
```
In order to fix this, I tried `__x64_sys_execve` and `do_execve`.  Both appear to allow the daemon to proceed with initialization and to properly operate the packet filter.  The UI connects to the daemon and pops up windows upon alerts with no issue.