### PR TITLE
Fixes issue #197 - modified user stats to use pwd.getpwuid 

### DIFF
--- a/ui/opensnitch/dialogs/stats.py
+++ b/ui/opensnitch/dialogs/stats.py
@@ -176,7 +176,6 @@ class StatsDialog(QtWidgets.QDialog, uic.loadUiType(DIALOG_UI_PATH)[0]):
 
     @QtCore.pyqtSlot()
     def _on_update_triggered(self):
-        pw_name = "(UID error)"
         if self.daemon_connected:
             self._status_label.setText("running")
             self._status_label.setStyleSheet('color: green')
@@ -206,6 +205,8 @@ class StatsDialog(QtWidgets.QDialog, uic.loadUiType(DIALOG_UI_PATH)[0]):
                         pw_name = pwd.getpwuid(int(uid)).pw_name
                     except KeyError:
                         pw_name = "(UID error)"
+                    except Exception:
+                        pw_name = "error"
                     finally:
                         by_users["%s (%s)" % (pw_name, uid)] = hits
             else:

--- a/ui/opensnitch/dialogs/stats.py
+++ b/ui/opensnitch/dialogs/stats.py
@@ -176,6 +176,7 @@ class StatsDialog(QtWidgets.QDialog, uic.loadUiType(DIALOG_UI_PATH)[0]):
 
     @QtCore.pyqtSlot()
     def _on_update_triggered(self):
+        pw_name = "(UID error)"
         if self.daemon_connected:
             self._status_label.setText("running")
             self._status_label.setStyleSheet('color: green')
@@ -202,7 +203,7 @@ class StatsDialog(QtWidgets.QDialog, uic.loadUiType(DIALOG_UI_PATH)[0]):
             if self._address is None:
                 for uid, hits in self._stats.by_uid.items():
                     try:
-                        pw_name = pwd.getpwall(int(uid)).pw_name
+                        pw_name = pwd.getpwuid(int(uid)).pw_name
                     except KeyError:
                         pw_name = "(UID error)"
                     finally:


### PR DESCRIPTION
This patch is to fix a problem where the UI would crash out whenever a dialog was responded to, first complaining that pw_name wasn't initialised, then that pwd.getpwall() doesn't normally take arguments. See #197 for more information.
