### PR TITLE
change pwall to pwuid (runtime error)

### DIFF
--- a/ui/opensnitch/dialogs/stats.py
+++ b/ui/opensnitch/dialogs/stats.py
@@ -202,7 +202,7 @@ class StatsDialog(QtWidgets.QDialog, uic.loadUiType(DIALOG_UI_PATH)[0]):
             if self._address is None:
                 for uid, hits in self._stats.by_uid.items():
                     try:
-                        pw_name = pwd.getpwall(int(uid)).pw_name
+                        pw_name = pwd.getpwuid(int(uid)).pw_name
                     except KeyError:
                         pw_name = "(UID error)"
                     finally:


### PR DESCRIPTION
The getpwall takes no arguments, and will cause a runtime error if called this way. 
I was getting a runtime unbound variable pw_name that was crashing the app.
The intent is to get user account for a given uid, so change to use pwuid function.