### PR TITLE
ui/opensnitch_ui.desktop: Drop MimeType declaration

### DIFF
--- a/ui/opensnitch_ui.desktop
+++ b/ui/opensnitch_ui.desktop
@@ -5,6 +5,5 @@ Exec=opensnitch-ui
 Icon=preferences-system-firewall
 GenericName=OpenSnitch Firewall
 Terminal=false
-MimeType=application/x-douane-configurator;
 Categories=System;Filesystem;Network;
 Keywords=system;firewall;policies;security;polkit;policykit;douane;


### PR DESCRIPTION
The desktop entry currently lists support for at least one mime type, but does not provide codes like `%f`, `%F`, `%u` or `%U` for the `Exec` key.

If the application can indeed handle files of the listed mime type, it should specify a way to pass the filenames as parameters, or it should not specify the `MimeType` key to begin with.