### PR TITLE
Fixes #228: Parse IP and port to uint

### DIFF
--- a/daemon/conman/connection.go
+++ b/daemon/conman/connection.go
@@ -18,9 +18,9 @@ import (
 type Connection struct {
 	Protocol string
 	SrcIP    net.IP
-	SrcPort  int
+	SrcPort  uint
 	DstIP    net.IP
-	DstPort  int
+	DstPort  uint
 	DstHost  string
 	Entry    *netstat.Entry
 	Process  *procmon.Process
@@ -137,15 +137,15 @@ func (c *Connection) parseDirection() bool {
 		if layer.LayerType() == layers.LayerTypeTCP {
 			if tcp, ok := layer.(*layers.TCP); ok == true && tcp != nil {
 				c.Protocol = "tcp"
-				c.DstPort = int(tcp.DstPort)
-				c.SrcPort = int(tcp.SrcPort)
+				c.DstPort = uint(tcp.DstPort)
+				c.SrcPort = uint(tcp.SrcPort)
 				ret = true
 			}
 		} else if layer.LayerType() == layers.LayerTypeUDP {
 			if udp, ok := layer.(*layers.UDP); ok == true && udp != nil {
 				c.Protocol = "udp"
-				c.DstPort = int(udp.DstPort)
-				c.SrcPort = int(udp.SrcPort)
+				c.DstPort = uint(udp.DstPort)
+				c.SrcPort = uint(udp.SrcPort)
 				ret = true
 			}
 		}

--- a/daemon/netstat/entry.go
+++ b/daemon/netstat/entry.go
@@ -7,14 +7,14 @@ import (
 type Entry struct {
 	Proto   string
 	SrcIP   net.IP
-	SrcPort int
+	SrcPort uint
 	DstIP   net.IP
-	DstPort int
+	DstPort uint
 	UserId  int
 	INode   int
 }
 
-func NewEntry(proto string, srcIP net.IP, srcPort int, dstIP net.IP, dstPort int, userId int, iNode int) Entry {
+func NewEntry(proto string, srcIP net.IP, srcPort uint, dstIP net.IP, dstPort uint, userId int, iNode int) Entry {
 	return Entry{
 		Proto:   proto,
 		SrcIP:   srcIP,

--- a/daemon/netstat/find.go
+++ b/daemon/netstat/find.go
@@ -6,7 +6,7 @@ import (
 	"github.com/evilsocket/opensnitch/daemon/log"
 )
 
-func FindEntry(proto string, srcIP net.IP, srcPort int, dstIP net.IP, dstPort int) *Entry {
+func FindEntry(proto string, srcIP net.IP, srcPort uint, dstIP net.IP, dstPort uint) *Entry {
 	entries, err := Parse(proto)
 	if err != nil {
 		log.Warning("Error while searching for %s netstat entry: %s", proto, err)

--- a/daemon/netstat/parse.go
+++ b/daemon/netstat/parse.go
@@ -36,32 +36,32 @@ func decToInt(n string) int {
 	return int(d)
 }
 
-func hexToInt(h string) int {
-	d, err := strconv.ParseInt(h, 16, 64)
+func hexToInt(h string) uint {
+	d, err := strconv.ParseUint(h, 16, 64)
 	if err != nil {
 		log.Fatal("Error while parsing %s to int: %s", h, err)
 	}
-	return int(d)
+	return uint(d)
 }
 
 
-func hexToInt2(h string) (int, int) {
+func hexToInt2(h string) (uint, uint) {
 	if len(h) > 16 {
-		d, err := strconv.ParseInt(h[:16], 16, 64)
+		d, err := strconv.ParseUint(h[:16], 16, 64)
 		if err != nil {
 			log.Fatal("Error while parsing %s to int: %s", h[16:], err)
 		}
-		d2, err := strconv.ParseInt(h[16:], 16, 64)
+		d2, err := strconv.ParseUint(h[16:], 16, 64)
 		if err != nil {
 			log.Fatal("Error while parsing %s to int: %s", h[16:], err)
 		}
-		return int(d), int(d2)
+		return uint(d), uint(d2)
 	} else {
-		d, err := strconv.ParseInt(h, 16, 64)
+		d, err := strconv.ParseUint(h, 16, 64)
 		if err != nil {
 			log.Fatal("Error while parsing %s to int: %s", h[16:], err)
 		}
-		return int(d), 0
+		return uint(d), 0
 	}
 }
 


### PR DESCRIPTION
Fixes a crash caused by trying to parse too large hexadecimal numbers into signed ints. Parses to uint instead.
For issue #228 