### PR TITLE
build the ui into a wheel, using a venv 

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,13 @@ The new `opensnitchd` service will log to `/var/log/opensnitchd.log`, save the r
 The user interface is a Python 3 software running as a `gRPC` server on a unix socket, to order to install its dependencies:
 
     cd ui
-    sudo pip3 install -r requirements.txt
+    make
 
-You will also need to install the package `python-pyqt5` for your system (if anyone finds a way to make this work from 
-the `requirements.txt` file feel free to send a PR).
+This build a python wheel package and puts it into the `dist` directory.  You can install it via
 
-The UI is pip installable itself:
+    sudo pip3 install dist/*.whl
 
-    sudo pip3 install .
+which will also cause it to install all of its dependencies.
 
 This will install the `opensnitch-ui` command on your system (you can auto startup it by `cp opensnitch_ui.desktop ~/.config/autostart/`).
   

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -3,3 +3,4 @@ build
 dist
 *.egg-info
 __pycache__
+/vbuildtools

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -1,14 +1,23 @@
-all: opensnitch/resources_rc.py
+all: wheel
 
-install:
-	@pip3 install .
+.PHONY: install
+install: wheel
+	@pip3 install dist/opensnitch_ui*.whl
 
-opensnitch/resources_rc.py: deps
-	@pyrcc5 -o opensnitch/resources_rc.py opensnitch/res/resources.qrc
+opensnitch/res/resources_rc.qrc: opensnitch/resources_rc.py vbuildtools
+	@vbuildtools/bin/pyrcc5 -o opensnitch/resources_rc.py opensnitch/res/resources.qrc
 
-deps:
-	@sudo pip3 install -r requirements.txt
+vbuildtools:
+	python3 -m venv vbuildtools
+	# install build dependencies ; runtime dependencies go in setup.py
+	vbuildtools/bin/pip install pyqt5 wheel
 
+.PHONY: wheel
+wheel: vbuildtools
+	vbuildtools/bin/python setup.py bdist_wheel
+
+.PHONY: clean
 clean:
-	@rm -rf *.pyc
+	@rm -rf *.pyc vbuildtools
 	@rm -rf opensnitch/resources_rc.py
+

--- a/ui/requirements.txt
+++ b/ui/requirements.txt
@@ -1,6 +1,0 @@
-grpcio==1.0.0
-grpcio-tools==1.10.1
-pyinotify==0.9.6
-unicode_slugify==0.1.3
-pyqt5==5.10.1
-configparser==3.5.0

--- a/ui/setup.py
+++ b/ui/setup.py
@@ -7,7 +7,7 @@ path = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(path)
 
 from opensnitch.version import version
-        
+
 setup(name='opensnitch-ui',
       version=version,
       description='Prompt service and UI for the opensnitch application firewall.',
@@ -20,5 +20,13 @@ setup(name='opensnitch-ui',
       package_data={'': ['*.*']},
       data_files=[('/usr/share/applications', ['opensnitch_ui.desktop']),
                ('/usr/share/kservices5', ['kcm_opensnitch.desktop'])],
-      scripts = [ 'bin/opensnitch-ui' ],
+      scripts=[ 'bin/opensnitch-ui' ],
+      install_requires=[
+          'grpcio==1.0.0',
+          'grpcio-tools==1.10.1',
+          'pyinotify==0.9.6',
+          'unicode_slugify==0.1.3',
+          'pyqt5==5.10.1',
+          'configparser==3.5.0',
+      ],
       zip_safe=False)


### PR DESCRIPTION
Build it into a wheel so installing it will automatically pull in dependencies.

Build it using a venv so the tooling isn't polluting the global system when we don't need it.