### PR TITLE
UI: improve regex for domain matching

### DIFF
--- a/ui/opensnitch/dialogs/prompt.py
+++ b/ui/opensnitch/dialogs/prompt.py
@@ -232,7 +232,7 @@ class PromptDialog(QtWidgets.QDialog, uic.loadUiType(DIALOG_UI_PATH)[0]):
         else:
             self._rule.operator.type = "regexp"
             self._rule.operator.operand = "dest.host"
-            self._rule.operator.data = ".*%s" % '\.'.join(self._con.dst_host.split('.')[what_idx - 4:])
+            self._rule.operator.data = ".*\.%s" % '\.'.join(self._con.dst_host.split('.')[what_idx - 4:])
 
         self._rule.name = slugify("%s %s %s" % (self._rule.action, self._rule.operator.type, self._rule.operator.data))
         


### PR DESCRIPTION
Hi there,
this should resolve #252 by adding an additional dot in front of the selected domain.
So that the created regex looks like `.*\.apple\.com` instead of `.*apple\.com`