### PR TITLE
Also detect applications that use the AF_INET6 socket for IPv4 connections (like Java)

### DIFF
--- a/daemon/netstat/find.go
+++ b/daemon/netstat/find.go
@@ -2,11 +2,27 @@ package netstat
 
 import (
 	"net"
-
+	"strings"
+	
 	"github.com/evilsocket/opensnitch/daemon/log"
 )
 
 func FindEntry(proto string, srcIP net.IP, srcPort uint, dstIP net.IP, dstPort uint) *Entry {
+	if entry := findEntryForProtocol(proto, srcIP, srcPort, dstIP, dstPort); entry != nil {
+		return entry
+	}
+
+	ipv6Suffix := "6"
+	if strings.HasSuffix(proto, ipv6Suffix) == false {
+		otherProto := proto + ipv6Suffix
+		log.Debug("Searching for %s netstat entry instead of %s", otherProto, proto)
+		return findEntryForProtocol(otherProto, srcIP, srcPort, dstIP, dstPort)
+	}
+	
+	return nil;
+}
+
+func findEntryForProtocol(proto string, srcIP net.IP, srcPort uint, dstIP net.IP, dstPort uint) *Entry {
 	entries, err := Parse(proto)
 	if err != nil {
 		log.Warning("Error while searching for %s netstat entry: %s", proto, err)


### PR DESCRIPTION
This change should fix #206 (Java applications are not noticed by OpenSnitch). It was made possible thanks to the IPv6 support provided by @jkozera.

Some applications (especially Java-based) use the AF_INET6 socket for IPv4 communication. Those connections were previously not detected. With this patch it might work better.

You can test this as follows:
1. Install OpenJDK `sudo apt install openjdk-11-jdk-headless`
2. Open the Java REPL by executing `$ jshell`
3. Inside JShell enter following Java code which makes a HTTP Request to github.com:
4. `((HttpURLConnection) new URL("https://github.com").openConnection()).getResponseCode()`

Without this patch the connection to github.com goes through without prompting, with the patch applied OpenSnitch can catch it.

Leave jshell with `/exit`.