### PR TITLE
Fixed race condition when reading and collecting stats

### DIFF
--- a/daemon/statistics/stats.go
+++ b/daemon/statistics/stats.go
@@ -26,7 +26,7 @@ type conEvent struct {
 }
 
 type Statistics struct {
-	sync.Mutex
+	sync.RWMutex
 
 	Started      time.Time
 	DNSResponses int

--- a/daemon/ui/client.go
+++ b/daemon/ui/client.go
@@ -125,10 +125,13 @@ func (c *Client) ping(ts time.Time) (err error) {
 	defer cancel()
 	reqId := uint64(ts.UnixNano())
 
-	pong, err := c.client.Ping(ctx, &protocol.PingRequest{
+    pReq := &protocol.PingRequest{
 		Id:    reqId,
 		Stats: c.stats.Serialize(),
-	})
+	}
+    c.stats.RLock()
+    pong, err := c.client.Ping(ctx, &pReq)
+    c.stats.RUnlock()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
PR proposal to fix #265 . When reading stats, a race can occur when sending them to remote UI via
protocol.Ping() if at the same time more stats are being collected(written).