### PR TITLE
Allow to configure daemon's default action rule

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -151,7 +151,6 @@ func onPacket(packet netfilter.Packet) {
 			packet.SetVerdict(netfilter.NF_ACCEPT)
 		} else {
 			if uiClient.DefaultDuration() == rule.Always {
-				log.Error("onPacket() connection parse error(null), default action DROP")
 				packet.SetVerdictAndMark(netfilter.NF_DROP, firewall.DropMark)
 			} else {
 				packet.SetVerdict(netfilter.NF_DROP)

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -147,8 +147,16 @@ func onPacket(packet netfilter.Packet) {
 	// Parse the connection state
 	con := conman.Parse(packet)
 	if con == nil {
-		packet.SetVerdict(netfilter.NF_ACCEPT)
-		stats.OnIgnored()
+		if uiClient.DefaultAction() == rule.Allow {
+			packet.SetVerdict(netfilter.NF_ACCEPT)
+		} else {
+			if uiClient.DefaultDuration() == rule.Always {
+				log.Error("onPacket() connection parse error(null), default action DROP")
+				packet.SetVerdictAndMark(netfilter.NF_DROP, firewall.DropMark)
+			} else {
+				packet.SetVerdict(netfilter.NF_DROP)
+			}
+		}
 		return
 	}
 

--- a/daemon/ui/client.go
+++ b/daemon/ui/client.go
@@ -78,6 +78,14 @@ func (c *Client) loadConfiguration() {
 	}
 }
 
+func (c *Client) DefaultAction() rule.Action {
+	return clientDisconnectedRule.Action
+}
+
+func (c *Client) DefaultDuration() rule.Duration {
+	return clientDisconnectedRule.Duration
+}
+
 func (c *Client) Connected() bool {
 	c.Lock()
 	defer c.Unlock()

--- a/daemon/ui/client.go
+++ b/daemon/ui/client.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"encoding/json"
+	"io/ioutil"
 	"fmt"
 	"net"
 	"strings"
@@ -20,9 +22,15 @@ import (
 )
 
 var (
+	configFile             = "/etc/opensnitchd/default-config.json"
 	clientDisconnectedRule = rule.Create("ui.client.disconnected", rule.Allow, rule.Once, rule.NewOperator(rule.Simple, rule.OpTrue, "", make([]rule.Operator, 0)))
 	clientErrorRule        = rule.Create("ui.client.error", rule.Allow, rule.Once, rule.NewOperator(rule.Simple, rule.OpTrue, "", make([]rule.Operator, 0)))
 )
+
+type Config struct {
+    Default_Action   string
+    Default_Duration string
+}
 
 type Client struct {
 	sync.Mutex
@@ -44,9 +52,30 @@ func NewClient(path string, stats *statistics.Statistics) *Client {
 		c.isUnixSocket = true
 		c.socketPath = c.socketPath[7:]
 	}
+	c.loadConfiguration()
 
 	go c.poller()
 	return c
+}
+
+func (c *Client) loadConfiguration() {
+    raw, err := ioutil.ReadFile(confFile)
+    if err != nil {
+        fmt.Errorf("Error loading configuration %s: %s", confFile, err)
+    }
+
+    var conf Config
+    err = json.Unmarshal(raw, &conf)
+    if err != nil {
+        fmt.Errorf("Error parsing configuration %s: %s", confFile, err)
+    }
+
+    if conf.Default_Action != "" {
+        clientDisconnectedRule.Action = rule.Action(conf.Default_Action)
+	}
+    if conf.Default_Duration != "" {
+        clientDisconnectedRule.Duration = rule.Duration(conf.Default_Duration)
+	}
 }
 
 func (c *Client) Connected() bool {


### PR DESCRIPTION
If the file /etc/opensnitchd/default-config.json exists,
read it and apply the options to the default rule when there's no client
connected.

If it doesn't exist, just apply the default rule, allow connections
once.

Config example: {"default_action": "deny", "default_duration": "once"}

thread #262 