### PR TITLE
Fixed unwanted rules reloading after adding a new one

### DIFF
--- a/daemon/rule/loader.go
+++ b/daemon/rule/loader.go
@@ -87,7 +87,7 @@ func (l *Loader) Load(path string) error {
 		l.rules[r.Name] = &r
 	}
 	for ruleName, inMemoryRule := range l.rules {
-		if val, ok := disk_rules[ruleName]; ok == false {
+		if _, ok := disk_rules[ruleName]; ok == false {
 			if inMemoryRule.Duration == Always {
 				log.Debug("Rule deleted from disk, updating rules list: ", ruleName)
 				delete(l.rules, ruleName)


### PR DESCRIPTION
When adding a new permanent rule, the temporary ones are deleted, so the
user is prompted again to allow/deny connections.

fixes #271 