### PR TITLE
Disable always-on focus on cmdCleanSql button.

### DIFF
--- a/ui/opensnitch/res/stats.ui
+++ b/ui/opensnitch/res/stats.ui
@@ -449,6 +449,9 @@
             <iconset theme="edit-clear-all">
              <normaloff>../../../../../../../../../../../../../../../../../../../../../../../../../../.designer/backup</normaloff>../../../../../../../../../../../../../../../../../../../../../../../../../../.designer/backup</iconset>
            </property>
+           <property name="autoDefault">
+            <bool>false</bool>
+           </property>
           </widget>
          </item>
         </layout>


### PR DESCRIPTION
Right now because this button always has a focus if the user accidentally presses Enter even while typing in the Filter field, all db will be cleaned.