### PR TITLE
update systemd service file

### DIFF
--- a/daemon/opensnitchd.service
+++ b/daemon/opensnitchd.service
@@ -6,8 +6,6 @@ After=network.target
 
 [Service]
 Type=simple
-PermissionsStartOnly=true
-ExecStartPre=/bin/mkdir -p /etc/opensnitchd/rules
 ExecStart=/usr/local/bin/opensnitchd -rules-path /etc/opensnitchd/rules
 Restart=always
 RestartSec=30


### PR DESCRIPTION
It's better to let directory creation be handled by packaging, instead of executing it on every daemon start. On Arch Linux for example, that directory is already contained in the package.
When that line is removed `PermissionsStartOnly=true` can go as well, it's [deprecated](https://github.com/systemd/systemd/pull/10802) anyway.