### PR TITLE
Use daemon's event timestamp in UI.

### DIFF
--- a/daemon/statistics/event.go
+++ b/daemon/statistics/event.go
@@ -27,5 +27,6 @@ func (e *Event) Serialize() *protocol.Event {
 		Time:       e.Time.Format("2006-01-02 15:04:05"),
 		Connection: e.Connection.Serialize(),
 		Rule:       e.Rule.Serialize(),
+		Unixnano:   e.Time.UnixNano(),
 	}
 }

--- a/daemon/statistics/stats.go
+++ b/daemon/statistics/stats.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// max number of events to keep in the buffer
-	maxEvents = 50
+	maxEvents = 100
 	// max number of entries for each By* map
 	maxStats = 25
 )

--- a/proto/Makefile
+++ b/proto/Makefile
@@ -1,9 +1,9 @@
-all: ../daemon/ui/protocol/ui.pb.go ../ui/ui_pb2.py
+all: ../daemon/ui/protocol/ui.pb.go ../ui/opensnitch/ui_pb2.py
 
-../daemon/ui/protocol/ui.pb.go:
+../daemon/ui/protocol/ui.pb.go: ui.proto
 	protoc -I. ui.proto --go_out=plugins=grpc:../daemon/ui/protocol/
 
-../ui/ui_pb2.py:
+../ui/opensnitch/ui_pb2.py: ui.proto
 	python3 -m grpc_tools.protoc -I. --python_out=../ui/opensnitch/ --grpc_python_out=../ui/opensnitch/ ui.proto
 
 clean:

--- a/proto/ui.proto
+++ b/proto/ui.proto
@@ -13,6 +13,7 @@ message Event {
     string time = 1;
     Connection connection = 2;
     Rule rule = 3;
+    int64 unixnano = 4;
 }
 
 message Statistics {


### PR DESCRIPTION
- Use daemon's event timestamp in UI.
- Use the timestamp instead of the event object when iterating over the last events. ~15x speed increase.
- Increase event buffer to 100. On my machine I routinely hit the ceiling of 50 events under some multitasking workloads which results in new connections not being logged.