### PR TITLE
fix logging when flag is passed on command line

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -92,11 +92,15 @@ func setupLogging() {
 		log.SetLogLevel(log.INFO)
 	}
 
-	if logFile != "" {
-		log.Close()
-		if err := log.OpenFile(logFile); err != nil {
-			log.Error("Error opening user defined log: %s %s", logFile, err)
-		}
+	var logFileToUse string
+	if logFile == "" {
+		logFileToUse = log.StdoutFile
+	} else {
+		logFileToUse = logFile
+	}
+	log.Close()
+	if err := log.OpenFile(logFileToUse); err != nil {
+		log.Error("Error opening user defined log: %s %s", logFileToUse, err)
 	}
 }
 


### PR DESCRIPTION
This should solve https://github.com/gustavo-iniguez-goya/opensnitch/issues/82

Without this patch passing -debug on command line has no effect because
`ui.NewClient ` reads the config and sets a logfile.
We explicitely set `logFileToUse = log.StdoutFile` and restore the expected behaviour. 