### PR TITLE
wait for success when sending packet to chan, don't error out after f…

### DIFF
--- a/daemon/netfilter/queue.go
+++ b/daemon/netfilter/queue.go
@@ -16,9 +16,9 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/evilsocket/opensnitch/daemon/log"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
-	"github.com/evilsocket/opensnitch/daemon/log"
 )
 
 const (
@@ -236,7 +236,7 @@ func go_callback(queueID C.int, data *C.uchar, length C.int, mark C.uint, idx ui
 			}
 		}
 
-	default:
-		fmt.Fprintf(os.Stderr, "Error sending packet to queue channel %d\n", idx)
+	case <-time.After(1 * time.Millisecond):
+		fmt.Fprintf(os.Stderr, "Timed out while sending packet to queue channel %d\n", idx)
 	}
 }


### PR DESCRIPTION
…irst failed attempt.

When testing this patch under a heavy load of 300 new connections per second running for 12 hours, I saw a few timeouts.
This means that there are legitimate cases when sending the packet to the channel will not go through
no matter how long we wait.
However, compared to the old behavior, the amount of dropped packets decreased by a factor of 100x.

The value of timeout is chosen to be 1 millisecond, because it feels reasonable that if after so long the packet did
not go through, it is not due to a congested channel but due to some other error which will not go away even if we wait longer.