### PR TITLE
Support more recent protoc-gen-go

### DIFF
--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -6,14 +6,14 @@ require (
 	github.com/evilsocket/ftrace v1.2.0
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
-	github.com/golang/protobuf v1.0.0
+	github.com/golang/protobuf v1.5.0
 	github.com/google/gopacket v1.1.14
 	github.com/vishvananda/netlink v1.1.0
 	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df // indirect
-	golang.org/x/net v0.0.0-20180417003750-8d16fa6dc9a8
+	golang.org/x/net v0.0.0-20190311183353-d8887717615a
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 // indirect
 	golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444 // indirect
 	golang.org/x/text v0.3.0 // indirect
-	google.golang.org/genproto v0.0.0-20180413175816-7fd901a49ba6 // indirect
-	google.golang.org/grpc v1.11.3
+	google.golang.org/grpc v1.27.0
+	google.golang.org/protobuf v1.26.0
 )

--- a/proto/Makefile
+++ b/proto/Makefile
@@ -1,7 +1,7 @@
 all: ../daemon/ui/protocol/ui.pb.go ../ui/opensnitch/ui_pb2.py
 
 ../daemon/ui/protocol/ui.pb.go: ui.proto
-	protoc -I. ui.proto --go_out=plugins=grpc:../daemon/ui/protocol/
+	protoc -I. ui.proto --go_out=plugins=grpc:../daemon/ui/protocol/ --go_opt=paths=source_relative
 
 ../ui/opensnitch/ui_pb2.py: ui.proto
 	python3 -m grpc_tools.protoc -I. --python_out=../ui/opensnitch/ --grpc_python_out=../ui/opensnitch/ ui.proto

--- a/proto/ui.proto
+++ b/proto/ui.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package protocol;
 
+option go_package = "github.com/evilsocket/opensnitch/daemon/ui/protocol";
+
 service UI {
     rpc Ping(PingRequest) returns (PingReply) {}
     rpc AskRule (Connection) returns (Rule) {}


### PR DESCRIPTION
When building the project with protoc-gen-go version 1.5.1,
it fails with the following:

```
protoc -I. ui.proto --go_out=plugins=grpc:../daemon/ui/protocol/
protoc-gen-go: unable to determine Go import path for "ui.proto"

Please specify either:
	• a "go_package" option in the .proto source file, or
	• a "M" argument on the command line.

See https://developers.google.com/protocol-buffers/docs/reference/go-generated#package for more information.

--go_out: protoc-gen-go: Plugin failed with status code 1.
```

This can be fixed by adding the full go package as an option in the
proto file. To make sure the code is generated to the correct path,
we also have to add add the `paths=source_relative` option to the
protoc plugin.

After this, the code is generated correctly, but the generated code
references classes like grpc.ClientConnInterface which were introduced
in 1.27.0.