### PR TITLE
Allow using newer grpcio-tools

### DIFF
--- a/ui/requirements.txt
+++ b/ui/requirements.txt
@@ -1,4 +1,4 @@
-grpcio-tools==1.10.1
+grpcio-tools>=1.10.1
 pyinotify==0.9.6
 unicode_slugify==0.1.3
 pyqt5>=5.6


### PR DESCRIPTION
My OS comes with grpcio-tools 1.36.1, which seems to work fine, so it
would be nice to allow the ui to use that instead of building 1.10.1
specifically for opensnitch.