### PR TITLE
Fix generating ui.pb.go on Ubuntu 18.04

### DIFF
--- a/proto/Makefile
+++ b/proto/Makefile
@@ -1,7 +1,10 @@
 all: ../daemon/ui/protocol/ui.pb.go ../ui/opensnitch/ui_pb2.py
 
 ../daemon/ui/protocol/ui.pb.go: ui.proto
-	protoc -I. ui.proto --go_out=plugins=grpc:../daemon/ui/protocol/ --go_opt=paths=source_relative
+	# This assumes protoc-gen-go prior to v1.20.0, which you can get with
+	# `go get github.com/golang/protobuf/protoc-gen-go` (and not with
+	# `go get google.golang.org/protobuf/cmd/protoc-gen-go`)
+	protoc -I. ui.proto --go_out=plugins=grpc,paths=source_relative:../daemon/ui/protocol/
 
 ../ui/opensnitch/ui_pb2.py: ui.proto
 	python3 -m grpc_tools.protoc -I. --python_out=../ui/opensnitch/ --grpc_python_out=../ui/opensnitch/ ui.proto


### PR DESCRIPTION
This was broken because on Ubuntu 18.04, the '--go_opt' protoc option is not
yet available.

Also clarify that for `plugins=grpc` to work, you need an older version of
`protoc-gen-go`, which you can still get through `go get
github.com/golang/protobuf/protoc-gen-go`.

https://stackoverflow.com/questions/62909028/unknown-flag-go-opt-while-regenerating-grpc-code