### PR TITLE
Allow to intercept more kernel connections

### DIFF
--- a/daemon/procmon/details.go
+++ b/daemon/procmon/details.go
@@ -41,7 +41,7 @@ func (p *Process) readComm() error {
 	if err != nil {
 		return err
 	}
-	p.Comm = string(data)
+	p.Comm = core.Trim(string(data))
 	return nil
 }
 

--- a/daemon/procmon/details.go
+++ b/daemon/procmon/details.go
@@ -36,6 +36,15 @@ func (p *Process) setCwd(cwd string) {
 	p.CWD = cwd
 }
 
+func (p *Process) readComm() error {
+	data, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/comm", p.ID))
+	if err != nil {
+		return err
+	}
+	p.Comm = string(data)
+	return nil
+}
+
 func (p *Process) readCwd() error {
 	link, err := os.Readlink(fmt.Sprintf("/proc/%d/cwd", p.ID))
 	if err != nil {
@@ -74,6 +83,9 @@ func (p *Process) readPath() error {
 
 func (p *Process) readCmdline() {
 	if data, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/cmdline", p.ID)); err == nil {
+		if len(data) == 0 {
+			return
+		}
 		for i, b := range data {
 			if b == 0x00 {
 				data[i] = byte(' ')

--- a/daemon/procmon/parse.go
+++ b/daemon/procmon/parse.go
@@ -116,7 +116,7 @@ func FindProcess(pid int, interceptUnknown bool) *Process {
 	// if the PID dir doesn't exist, the process may have exited or be a kernel connection
 	// XXX: can a kernel connection exist without an entry in ProcFS?
 	if core.Exists(fmt.Sprint("/proc/", pid)) == false {
-		log.Warning("PID can't be read /proc/", pid)
+		log.Debug("PID can't be read /proc/", pid)
 		return nil
 	}
 
@@ -129,7 +129,7 @@ func FindProcess(pid int, interceptUnknown bool) *Process {
 	proc.cleanPath()
 
 	if len(proc.Args) == 0 {
-		fmt.Println("cmdline empty")
+		proc.readComm()
 		proc.Args = make([]string, 0)
 		proc.Args = append(proc.Args, proc.Comm)
 	}
@@ -137,7 +137,6 @@ func FindProcess(pid int, interceptUnknown bool) *Process {
 	// If the link to the binary can't be read, the PID may be of a kernel task
 	if err != nil || proc.Path == "" {
 		proc.Path = "Kernel connection"
-		fmt.Printf("Kernel Comm: %s, cmdline: %v\n", proc.Comm, proc.Args)
 	}
 
 	addToActivePidsCache(uint64(pid), proc)

--- a/daemon/procmon/process.go
+++ b/daemon/procmon/process.go
@@ -46,6 +46,7 @@ type procStatm struct {
 // Process holds the details of a process.
 type Process struct {
 	ID          int
+	Comm        string
 	Path        string
 	Args        []string
 	Env         map[string]string


### PR DESCRIPTION
Some connections are initiated from kernel space, like WireGuard VPNs (#454), NFS or SMB connections (#502) and ip tunnels (#500).

More information regarding this change: #493

TODO:
- support for i386: there's an invalid access reading udp header.
- test it on arm*.