### PR TITLE
add Repology banner to wiki home

### DIFF
--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,3 +1,7 @@
+<a href="https://repology.org/project/opensnitch/versions">
+    <img src="https://repology.org/badge/vertical-allrepos/opensnitch.svg" alt="Packaging status" align="right">
+</a>
+
 Welcome to the opensnitch wiki!
 
 


### PR DESCRIPTION
Looks like this:

![Screenshot](https://scrumplex.rocks/img/1641461354.png)