### PR TITLE
Improve systemd service unit name

### DIFF
--- a/daemon/opensnitchd.service
+++ b/daemon/opensnitchd.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=OpenSnitch is a GNU/Linux port of the Little Snitch application firewall.
+Description=Application firewall OpenSnitch
 Documentation=https://github.com/gustavo-iniguez-goya/opensnitch/wiki
 Wants=network.target
 After=network.target

--- a/debian/opensnitch.service
+++ b/debian/opensnitch.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=OpenSnitch is a GNU/Linux application firewall.
+Description=Application firewall OpenSnitch
 Documentation=https://github.com/gustavo-iniguez-goya/opensnitch/wiki
 Wants=network.target
 After=network.target


### PR DESCRIPTION
It was a full sentence that looked out of place. Official documentation
of systemd recommends to make it a short capitalized label, preferably a
noun.
See [man page `systemd.unit`](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Description=).