### PR TITLE
Fix a minor typo

### DIFF
--- a/ui/i18n/locales/de_DE/opensnitch-de_DE.ts
+++ b/ui/i18n/locales/de_DE/opensnitch-de_DE.ts
@@ -616,7 +616,7 @@ Knoten an</translation>
     </message>
     <message>
         <location filename="../../../opensnitch/res/preferences.ui" line="461"/>
-        <source>Disable pop-ups, only display an notification</source>
+        <source>Disable pop-ups, only display a notification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/locales/es_ES/opensnitch-es_ES.ts
+++ b/ui/i18n/locales/es_ES/opensnitch-es_ES.ts
@@ -620,7 +620,7 @@ Si no respondes a la ventana emergente, se aplicarán las opciones por defecto</
     </message>
     <message>
         <location filename="../../../opensnitch/res/preferences.ui" line="461"/>
-        <source>Disable pop-ups, only display an notification</source>
+        <source>Disable pop-ups, only display a notification</source>
         <translation>Deshabilitar ventanas emergentes, sólo mostrar notificaciones</translation>
     </message>
     <message>

--- a/ui/i18n/locales/eu_ES/opensnitch-eu_ES.ts
+++ b/ui/i18n/locales/eu_ES/opensnitch-eu_ES.ts
@@ -535,7 +535,7 @@
     </message>
     <message>
         <location filename="../../../opensnitch/res/preferences.ui" line="461"/>
-        <source>Disable pop-ups, only display an notification</source>
+        <source>Disable pop-ups, only display a notification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/locales/fr_FR/opensnitch-fr_FR.ts
+++ b/ui/i18n/locales/fr_FR/opensnitch-fr_FR.ts
@@ -615,7 +615,7 @@ es que no hemos descubierto el PID (por ejemplo conexiones que no se originan en
     </message>
     <message>
         <location filename="../../../opensnitch/res/preferences.ui" line="461"/>
-        <source>Disable pop-ups, only display an notification</source>
+        <source>Disable pop-ups, only display a notification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/locales/hu_HU/opensnitch-hu_HU.ts
+++ b/ui/i18n/locales/hu_HU/opensnitch-hu_HU.ts
@@ -645,7 +645,7 @@
     </message>
     <message>
         <location filename="../../../opensnitch/res/preferences.ui" line="461"/>
-        <source>Disable pop-ups, only display an notification</source>
+        <source>Disable pop-ups, only display a notification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/locales/ja_JP/opensnitch-ja_JP.ts
+++ b/ui/i18n/locales/ja_JP/opensnitch-ja_JP.ts
@@ -630,7 +630,7 @@
     </message>
     <message>
         <location filename="../../../opensnitch/res/preferences.ui" line="461"/>
-        <source>Disable pop-ups, only display an notification</source>
+        <source>Disable pop-ups, only display a notification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/i18n/locales/pt_BR/opensnitch-pt_BR.ts
+++ b/ui/i18n/locales/pt_BR/opensnitch-pt_BR.ts
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+f<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="pt_BR">
 <context>
@@ -656,7 +656,7 @@
     </message>
     <message>
         <location filename="../../../opensnitch/res/preferences.ui" line="461"/>
-        <source>Disable pop-ups, only display an notification</source>
+        <source>Disable pop-ups, only display a notification</source>
         <translation>Desativar pop-ups, exibir apenas uma notificação</translation>
     </message>
     <message>

--- a/ui/i18n/locales/pt_BR/opensnitch-pt_BR.ts
+++ b/ui/i18n/locales/pt_BR/opensnitch-pt_BR.ts
@@ -1,4 +1,4 @@
-f<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
 <TS version="2.1" language="pt_BR">
 <context>

--- a/ui/i18n/locales/ro_RO/opensnitch-ro_RO.ts
+++ b/ui/i18n/locales/ro_RO/opensnitch-ro_RO.ts
@@ -535,7 +535,7 @@
     </message>
     <message>
         <location filename="../../../opensnitch/res/preferences.ui" line="461"/>
-        <source>Disable pop-ups, only display an notification</source>
+        <source>Disable pop-ups, only display a notification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/ui/opensnitch/res/preferences.ui
+++ b/ui/opensnitch/res/preferences.ui
@@ -458,7 +458,7 @@
        <item row="0" column="0" colspan="3">
         <widget class="QLabel" name="label_16">
          <property name="text">
-          <string>Disable pop-ups, only display an notification</string>
+          <string>Disable pop-ups, only display a notification</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>


### PR DESCRIPTION
This PR fixes the following typo:
`Disable pop-ups, only display an notification` to `Disable pop-ups, only display a notification`