### PR TITLE
Allow building on systems using musl

### DIFF
--- a/daemon/netfilter/queue.go
+++ b/daemon/netfilter/queue.go
@@ -92,7 +92,7 @@ func (q *Queue) create(queueID uint16) (err error) {
 		return fmt.Errorf("Error binding to AF_INET protocol family: %v", err)
 	} else if ret, err := C.nfq_bind_pf(q.h, AF_INET6); err != nil || ret < 0 {
 		return fmt.Errorf("Error binding to AF_INET6 protocol family: %v", err)
-	} else if q.qh, err = C.CreateQueue(q.h, C.u_int16_t(queueID), C.u_int32_t(q.idx)); err != nil || q.qh == nil {
+	} else if q.qh, err = C.CreateQueue(q.h, C.uint16_t(queueID), C.uint32_t(q.idx)); err != nil || q.qh == nil {
 		q.destroy()
 		return fmt.Errorf("Error binding to queue: %v", err)
 	}
@@ -107,14 +107,14 @@ func (q *Queue) create(queueID uint16) (err error) {
 func (q *Queue) setup() (err error) {
 	var ret C.int
 
-	queueSize := C.u_int32_t(NF_DEFAULT_QUEUE_SIZE)
+	queueSize := C.uint32_t(NF_DEFAULT_QUEUE_SIZE)
 	bufferSize := C.uint(NF_DEFAULT_PACKET_SIZE)
 	totSize := C.uint(NF_DEFAULT_QUEUE_SIZE * NF_DEFAULT_PACKET_SIZE)
 
 	if ret, err = C.nfq_set_queue_maxlen(q.qh, queueSize); err != nil || ret < 0 {
 		q.destroy()
 		return fmt.Errorf("Unable to set max packets in queue: %v", err)
-	} else if C.nfq_set_mode(q.qh, C.u_int8_t(2), bufferSize) < 0 {
+	} else if C.nfq_set_mode(q.qh, C.uint8_t(2), bufferSize) < 0 {
 		q.destroy()
 		return fmt.Errorf("Unable to set packets copy mode: %v", err)
 	} else if q.fd, err = C.nfq_fd(q.h); err != nil {

--- a/daemon/netfilter/queue.h
+++ b/daemon/netfilter/queue.h
@@ -15,16 +15,16 @@
 #include <libnetfilter_queue/libnetfilter_queue.h>
 
 typedef struct {
-    uint verdict;
-    uint mark;
-    uint mark_set;
-    uint length;
+    unsigned int verdict;
+    unsigned int mark;
+    unsigned int mark_set;
+    unsigned int length;
     unsigned char *data;
 } verdictContainer;
 
 static void *get_uid = NULL;
 
-extern void go_callback(int id, unsigned char* data, int len, uint mark, u_int32_t idx, verdictContainer *vc, uint32_t uid);
+extern void go_callback(int id, unsigned char* data, int len, unsigned int mark, uint32_t idx, verdictContainer *vc, uint32_t uid);
 
 static uint8_t stop = 0;
 
@@ -80,7 +80,7 @@ static int nf_callback(struct nfq_q_handle *qh, struct nfgenmsg *nfmsg, struct n
     return nfq_set_verdict2(qh, id, vc.verdict, vc.mark, vc.length, vc.data);
 }
 
-static inline struct nfq_q_handle* CreateQueue(struct nfq_handle *h, u_int16_t queue, u_int32_t idx) {
+static inline struct nfq_q_handle* CreateQueue(struct nfq_handle *h, uint16_t queue, uint32_t idx) {
     struct nfq_q_handle* qh = nfq_create_queue(h, queue, &nf_callback, (void*)((uintptr_t)idx));
     if (qh == NULL){
         printf("ERROR: nfq_create_queue() queue not created\n");


### PR DESCRIPTION
Currently `queue.go` and `queue.h` use nonstandard type definitions which are unsupported by the musl libc implementation. This PR changes the definitions to be standard and allows the project to compile on musl.