### PR TITLE
`pip uninstall` that accounts transient dependencies

### DIFF
--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -117,4 +117,4 @@ Remove the packages + rules + configuration:
 - `yum remove opensnitch opensnitch-ui` or `zypper remove opensnitch opensnitch-ui`
 
 If you installed pip packages:
-- `pip3 uninstall grpcio-tools unicode_slugify pyinotify`
+- `pip3 uninstall grpcio grpcio-tools unicode_slugify pyinotify PyQt5`

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -117,4 +117,5 @@ Remove the packages + rules + configuration:
 - `yum remove opensnitch opensnitch-ui` or `zypper remove opensnitch opensnitch-ui`
 
 If you installed pip packages:
-- `pip3 uninstall grpcio grpcio-tools unicode_slugify pyinotify PyQt5`
+- `pip3 uninstall grpcio-tools unicode_slugify pyinotify`
+- `pip3 uninstall grpcio PyQt5 Unidecode`_(transient dependencies, can check with `pip show` to validate how original installation was done. If you find installation location is not `/usr/lib/` then these are not installed through apt)_


### PR DESCRIPTION
Hey all,

Awesome application and glad to see it grow and improve over the years. I recently was making the upgrade from 1.3.x version to 1.5.0 and I noticed the latest application installs python packages using `apt` which is a wonderful add and makes me more comfortable with the installation process.

One thing I noticed running `sudo pip list` and `sudo pip show` is that the python package that will be used will still be the ones that were installed prior using `sudo pip` in `/usr/local/lib/` rather than the `apt` installed ones which land in `/usr/lib/`. I _think_ it would be better for users running older versions to actually `pip uninstall` these dependencies before running `apt` using the newer `deb`.

In addition to that I think the list of packages to be uninstalled can be extended a bit to include some of the transient dependencies that are pulled after having done `pip install` on older versions.