### PR TITLE
Fixes attachment of dns uprobes when libc is stripped of symbol names

### DIFF
--- a/daemon/dns/ebpfhook.go
+++ b/daemon/dns/ebpfhook.go
@@ -78,7 +78,7 @@ func findLibc() (string, error) {
 
 // Iterates over all symbols in an elf file and returns the offset matching the provided symbol name.
 func lookupSymbol(elffile *elf.File, symbolName string) (uint64, error) {
-	symbols, err := elffile.Symbols()
+	symbols, err := elffile.DynamicSymbols()
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
On arch linux, and likely other distros, [libc.so](http://libc.so/).6 is shipped stripped by default. this means `.symtab` does not exist and `elffile.Symbols()` returns with "no symbol section" error resulting in dns uprobes being unable to be attached. This pr changes the call to `.DynamicSymbols()` to alleviate this problem. This ensures a broader range of distro compatibility.

```EBPF-DNS: Failed to find symbol for uprobe uretprobe/gethostbyname : no symbol section
EBPF-DNS: Failed to find symbol for uprobe uprobe/getaddrinfo : no symbol section
EBPF-DNS: Failed to find symbol for uprobe uretprobe/getaddrinfo : no symbol section
EBPF-DNS: Failed to find symbols for uprobes.
EBPF-DNS: Unable to attach ebpf listener.```