### PR TITLE
fw: support for icmpv6 nftables in system rules

### DIFF
--- a/daemon/firewall/nftables/exprs/enums.go
+++ b/daemon/firewall/nftables/exprs/enums.go
@@ -170,4 +170,8 @@ const (
 	ICMP_ROUTER_SOLICITATION  = "router-solicitation"
 	ICMP_ADDRESS_MASK_REQUEST = "address-mask-request"
 	ICMP_ADDRESS_MASK_REPLY   = "address-mask-reply"
+
+	ICMP_PACKET_TOO_BIG          = "packet-too-big"
+	ICMP_NEIGHBOUR_SOLICITATION  = "neighbour-solicitation"
+	ICMP_NEIGHBOUR_ADVERTISEMENT = "neighbour-advertisement"
 )

--- a/daemon/firewall/nftables/exprs/protocol.go
+++ b/daemon/firewall/nftables/exprs/protocol.go
@@ -71,6 +71,16 @@ func NewExprProtocol(proto string) (*[]expr.Any, error) {
 			},
 		}, nil
 
+	case NFT_PROTO_ICMPv6:
+		return &[]expr.Any{
+			&expr.Meta{Key: expr.MetaKeyL4PROTO, Register: 1},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     []byte{unix.IPPROTO_ICMPV6},
+			},
+		}, nil
+
 	default:
 		return nil, fmt.Errorf("Not valid protocol rule, invalid or not supported protocol: %s", proto)
 	}

--- a/daemon/firewall/nftables/exprs/utils.go
+++ b/daemon/firewall/nftables/exprs/utils.go
@@ -78,6 +78,35 @@ func GetICMPType(icmpType string) uint8 {
 	return 0
 }
 
+// GetICMPv6Type returns an ICMPv6 type code
+func GetICMPv6Type(icmpType string) uint8 {
+	switch icmpType {
+	case ICMP_DEST_UNREACHABLE:
+		return layers.ICMPv6TypeDestinationUnreachable
+	case ICMP_PACKET_TOO_BIG:
+		return layers.ICMPv6TypePacketTooBig
+	case ICMP_TIME_EXCEEDED:
+		return layers.ICMPv6TypeTimeExceeded
+	case ICMP_PARAMETER_PROBLEM:
+		return layers.ICMPv6TypeParameterProblem
+	case ICMP_ECHO_REQUEST:
+		return layers.ICMPv6TypeEchoRequest
+	case ICMP_ECHO_REPLY:
+		return layers.ICMPv6TypeEchoReply
+	case ICMP_ROUTER_SOLICITATION:
+		return layers.ICMPv6TypeRouterSolicitation
+	case ICMP_ROUTER_ADVERTISEMENT:
+		return layers.ICMPv6TypeRouterAdvertisement
+	case ICMP_NEIGHBOUR_SOLICITATION:
+		return layers.ICMPv6TypeNeighborSolicitation
+	case ICMP_NEIGHBOUR_ADVERTISEMENT:
+		return layers.ICMPv6TypeNeighborAdvertisement
+	case ICMP_REDIRECT:
+		return layers.ICMPv6TypeRedirect
+	}
+	return 0
+}
+
 func getICMPv6RejectCode(reason string) uint8 {
 	switch reason {
 	case ICMP_HOST_UNREACHABLE, ICMP_NET_UNREACHABLE, ICMP_NO_ROUTE:

--- a/daemon/firewall/nftables/parser.go
+++ b/daemon/firewall/nftables/parser.go
@@ -71,7 +71,7 @@ func (n *Nft) parseExpression(table, chain, family string, expression *config.Ex
 		exprList = append(exprList, *exprIP...)
 
 	case exprs.NFT_PROTO_ICMP, exprs.NFT_PROTO_ICMPv6:
-		exprICMP := n.buildICMPRule(table, family, expression.Statement.Values)
+		exprICMP := n.buildICMPRule(table, family, expression.Statement.Name, expression.Statement.Values)
 		if exprICMP == nil {
 			log.Warning("%s icmp statement error", logTag)
 			return nil

--- a/daemon/system-fw.json
+++ b/daemon/system-fw.json
@@ -176,6 +176,31 @@
               "TargetParameters": ""
             },
             {
+              "Enabled": true,
+              "Position": 0,
+              "Description": "Allow ICMPv6",
+              "Expressions": [
+                {
+                  "Statement": {
+                    "Op": "",
+                    "Name": "icmpv6",
+                    "Values": [
+                      {
+                        "Key": "type",
+                        "Value": "echo-request"
+                      },
+                      {
+                        "Key": "type",
+                        "Value": "echo-reply"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "Target": "accept",
+              "TargetParameters": ""
+            },
+            {
               "Enabled": false,
               "Position": "0",
               "Description": "Exclude WireGuard VPN from being intercepted",


### PR DESCRIPTION
- Add support for all available nftables ICMPv6 types (ip6tables -m icmpv6 --help)
- Build nftables ICMPv6 rules
- Create a default outbound ICMPv6 echo-request/reply rule
  (currently outbound echo-request ICMPv6 is by default denied)
```
$ doas nft list table inet mangle
table inet mangle {
	chain output {
		type filter hook output priority mangle; policy accept;
		icmp type { echo-reply, echo-request } accept
		icmpv6 type { echo-request, echo-reply } accept
		ct state related,new queue flags bypass to 0
	}
[...]
```
