### PR TITLE
sys firewall: fixed wrong wireguard protocol

### DIFF
--- a/daemon/system-fw.json
+++ b/daemon/system-fw.json
@@ -209,7 +209,7 @@
                 {
                   "Statement": {
                     "Op": "",
-                    "Name": "tcp",
+                    "Name": "udp",
                     "Values": [
                       {
                         "Key": "dport",


### PR DESCRIPTION
Changed 'tcp' to 'udp' to make wireguard rule ```Exclude WireGuard VPN from being intercepted``` work.