### PR TITLE
daemon/Makefile: improvements to make distro packaging easier

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -6,10 +6,14 @@ all: opensnitchd
 
 install:
 	@mkdir -p $(DESTDIR)/etc/opensnitchd/rules
-	@cp opensnitchd $(DESTDIR)$(PREFIX)/bin/
-	@cp opensnitchd.service $(DESTDIR)/etc/systemd/system/
-	@cp default-config.json $(DESTDIR)/etc/opensnitchd/
-	@cp system-fw.json $(DESTDIR)/etc/opensnitchd/
+	@install -Dm755 opensnitchd \
+		-t $(DESTDIR)$(PREFIX)/bin/
+	@install -Dm644 opensnitchd.service \
+		-t $(DESTDIR)/etc/systemd/system/
+	@install -Dm644 default-config.json \
+		-t $(DESTDIR)/etc/opensnitchd/
+	@install -Dm644 system-fw.json \
+		-t $(DESTDIR)/etc/opensnitchd/
 	@systemctl daemon-reload
 
 opensnitchd: $(SRC)

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -1,14 +1,15 @@
 #SRC contains all *.go *.c *.h files in daemon/ and its subfolders 
 SRC := $(shell find . -type f -name '*.go' -o -name '*.h' -o -name '*.c')
+PREFIX?=/usr/local
 
 all: opensnitchd
 
 install:
-	@mkdir -p /etc/opensnitchd/rules
-	@cp opensnitchd /usr/local/bin/
-	@cp opensnitchd.service /etc/systemd/system/
-	@cp default-config.json /etc/opensnitchd/
-	@cp system-fw.json /etc/opensnitchd/
+	@mkdir -p $(DESTDIR)/etc/opensnitchd/rules
+	@cp opensnitchd $(DESTDIR)$(PREFIX)/bin/
+	@cp opensnitchd.service $(DESTDIR)/etc/systemd/system/
+	@cp default-config.json $(DESTDIR)/etc/opensnitchd/
+	@cp system-fw.json $(DESTDIR)/etc/opensnitchd/
 	@systemctl daemon-reload
 
 opensnitchd: $(SRC)


### PR DESCRIPTION
This is a handful of improvements to the daemon/Makefile that make it easier to package opensnitch on other distros. make's DESTDIR and PREFIX are widely used, and install is a very common way to handle installing/copying files/dirs to a location.

This *might* add some new dependency on `install` if some distro / environment doesn't include it, but it's a part of coreutils and busybox has a module for it... so it's likely everywhere already.