### PR TITLE
Use '$(MAKE) -C dir' instead of 'cd dir && make' when building in subdirectory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,22 @@
 all: protocol opensnitch_daemon gui
 
 install:
-	@cd daemon && make install	
-	@cd ui && make install
+	@$(MAKE) -C daemon install
+	@$(MAKE) -C ui install
 
 protocol:
-	@cd proto && make
+	@$(MAKE) -C proto
 
 opensnitch_daemon:
-	@cd daemon && make
+	@$(MAKE) -C daemon
 
 gui:
-	@cd ui && make
+	@$(MAKE) -C ui
 
 clean:
-	@cd daemon && make clean
-	@cd proto && make clean
-	@cd ui && make clean
+	@$(MAKE) -C daemon clean
+	@$(MAKE) -C proto clean
+	@$(MAKE) -C ui clean
 
 run:
 	cd ui && pip3 install --upgrade . && cd ..
@@ -25,18 +25,18 @@ run:
 
 test: 
 	clear 
-	make clean
+	$(MAKE) clean
 	clear
 	mkdir -p rules
-	make 
+	$(MAKE)
 	clear
-	make run
+	$(MAKE) run
 
 adblocker:
 	clear 
-	make clean
+	$(MAKE) clean
 	clear
-	make 
+	$(MAKE)
 	clear
 	python make_ads_rules.py
 	clear

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -8,7 +8,7 @@ opensnitch/resources_rc.py: translations deps
 	sed -i 's/^import ui_pb2/from . import ui_pb2/' opensnitch/ui_pb2*
 
 translations:
-	@cd i18n ; make
+	@$(MAKE) -C i18n
 	
 deps:
 	@pip3 install -r requirements.txt


### PR DESCRIPTION
This allow builders to control which make program to use and let make take care of changing the working directory.