### PR TITLE
Speed up Go build by using eatmydata.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,18 +18,19 @@ jobs:
 
     - name: Get dependencies
       run: |
-        sudo apt-get install git libnetfilter-queue-dev libmnl-dev libpcap-dev protobuf-compiler
+        sudo apt --yes --quiet install --no-install-suggests eatmydata
+        sudo eatmydata apt-get install git libnetfilter-queue-dev libmnl-dev libpcap-dev protobuf-compiler
         export GOPATH=~/go
         export PATH=$PATH:$GOPATH/bin
-        go get github.com/golang/protobuf/protoc-gen-go
-        go install google.golang.org/protobuf/cmd/protoc-gen-go
-        go get google.golang.org/grpc/cmd/protoc-gen-go-grpc
+        eatmydata go get github.com/golang/protobuf/protoc-gen-go
+        eatmydata go install google.golang.org/protobuf/cmd/protoc-gen-go
+        eatmydata go get google.golang.org/grpc/cmd/protoc-gen-go-grpc
         cd proto
-        make ../daemon/ui/protocol/ui.pb.go
+        eatmydata make ../daemon/ui/protocol/ui.pb.go
 
     - name: Build
       run: |
         cd daemon 
-        go mod tidy
-        go mod vendor
-        go build -v .
+        eatmydata go mod tidy
+        eatmydata go mod vendor
+        eatmydata go build -v .


### PR DESCRIPTION
The eatmydata package block programs from using file system sync, a kernel operation slowing down execution to ensure data reaches the disk before continuing.  No-one care if the hard disk got any data for the continous integration tests if the machine crashes halfway through the test, so this is just wasted time.