### PR TITLE
The GUI work better with python3-pyasn, added it as Recommends.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -75,6 +75,8 @@ Depends:
  python3-slugify,
  python3:any,
  whiptail | dialog
+Recommends:
+ python3-pyasn
 Suggests: python3-pyasn
 Description: opensnitch application firewall GUI
  opensnitch-ui is a GUI for opensnitch written in Python.


### PR DESCRIPTION
This will make it install by default, while still allowing the package to be installed without it.