### PR TITLE
Update workflow to go 1.19, actions bump, https chameleon, remove unused parameters

### DIFF
--- a/.github/workflows/build_ebpf_modules.yml
+++ b/.github/workflows/build_ebpf_modules.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
         - name: Check out code into the Go module directory
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             # ref: can be a branch name, tag, commit, etc
             ref: ${{ matrix.tag }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.15
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.15
+          go-version: 1.19
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get dependencies
         run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.15
+      - name: Set up Go 1.19
         uses: actions/setup-go@v3
         with:
           go-version: 1.19

--- a/ui/opensnitch/actions/highlight.py
+++ b/ui/opensnitch/actions/highlight.py
@@ -197,7 +197,7 @@ class Highlight():
 
         return (modified,)
 
-    def paintCell(self, style, painter, option, index, defaultPen, defaultBrush, cellAlignment, cellRect, cellColor, cellBgColor, cellValue):
+    def paintCell(self, style, painter, option, defaultPen, cellAlignment, cellRect, cellColor, cellBgColor, cellValue):
         cellSelected = option.state & QStyle.State_Selected
 
         painter.save()

--- a/utils/legacy/make_ads_rules.py
+++ b/utils/legacy/make_ads_rules.py
@@ -7,7 +7,7 @@ import os
 lists = ( \
     "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts",
     "https://mirror1.malwaredomains.com/files/justdomains",
-    "http://sysctl.org/cameleon/hosts",
+    "https://sysctl.org/cameleon/hosts",
     "https://zeustracker.abuse.ch/blocklist.php?download=domainblocklist",
     "https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt",
     "https://s3.amazonaws.com/lists.disconnect.me/simple_ad.txt",


### PR DESCRIPTION
Not sure if it will act up on go 1.19 for workflow. It shouldn’t since it’s their “promise of compatibility” but you never know. 

The actions bumps won’t cause issues, other changes include upgrading chameleons link to https, and removing unused function parameters