### PR TITLE
Added Debian package relation between opensnitch and python3-opensnitch-ui.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -39,6 +39,7 @@ Architecture: any
 Depends:
  ${misc:Depends},
  ${shlibs:Depends},
+Recommends: python3-opensnitch-ui
 Built-Using: ${misc:Built-Using}
 Description: GNU/Linux interactive application firewall
  OpenSnitch is a GNU/Linux firewall application.
@@ -78,6 +79,7 @@ Depends:
  gtk-update-icon-cache
 Recommends:
  python3-pyasn
+Suggests: opensnitch
 Description: GNU/Linux interactive application firewall GUI
  opensnitch-ui is a GUI for opensnitch written in Python.
  It allows the user to view live outgoing connections, as well as search


### PR DESCRIPTION
This ensure 'apt install opensnitch' by default also install the graphical user interface.  Also let the python3-opensnitch-ui package suggest opensnitch, to let users know about the daemon package.  Not using recommends here to avoid circular recommend relation between the two packages.