### PR TITLE
fixed typo, made tooltip text more conventional

### DIFF
--- a/ui/i18n/locales/de_DE/opensnitch-de_DE.ts
+++ b/ui/i18n/locales/de_DE/opensnitch-de_DE.ts
@@ -1474,7 +1474,7 @@ Sie müssen die Regel so benennen, dass sie zuerst überprüft wird, da sie in a
     </message>
     <message>
         <location filename="../../../opensnitch/res/stats.ui" line="287"/>
-        <source>Save to CSV.</source>
+        <source>Save to CSV</source>
         <translation type="obsolete">Als CSV exportieren.</translation>
     </message>
     <message>

--- a/ui/i18n/locales/es_ES/opensnitch-es_ES.ts
+++ b/ui/i18n/locales/es_ES/opensnitch-es_ES.ts
@@ -1374,7 +1374,7 @@ Debes nombrar la regla de tal manera que se compruebe de las primeras, ya que se
     </message>
     <message>
         <location filename="../../../opensnitch/res/stats.ui" line="287"/>
-        <source>Save to CSV.</source>
+        <source>Save to CSV</source>
         <translation type="obsolete">Exportar a CSV.</translation>
     </message>
     <message>

--- a/ui/i18n/locales/fr_FR/opensnitch-fr_FR.ts
+++ b/ui/i18n/locales/fr_FR/opensnitch-fr_FR.ts
@@ -1472,7 +1472,7 @@ Vous devez nommer la règle de façon qu'elle soit testée en premier, par ordre
     </message>
     <message>
         <location filename="../../../opensnitch/res/stats.ui" line="287"/>
-        <source>Save to CSV.</source>
+        <source>Save to CSV</source>
         <translation type="obsolete">Enregistrer au format CSV.</translation>
     </message>
     <message>

--- a/ui/i18n/locales/hu_HU/opensnitch-hu_HU.ts
+++ b/ui/i18n/locales/hu_HU/opensnitch-hu_HU.ts
@@ -1499,7 +1499,7 @@ A szabályt úgy kell megneveznie, hogy először ellenőrizni fogják, mert bet
     </message>
     <message>
         <location filename="../../../opensnitch/res/stats.ui" line="287"/>
-        <source>Save to CSV.</source>
+        <source>Save to CSV</source>
         <translation type="obsolete">Mentés CSV formátumban…</translation>
     </message>
     <message>

--- a/ui/i18n/locales/ja_JP/opensnitch-ja_JP.ts
+++ b/ui/i18n/locales/ja_JP/opensnitch-ja_JP.ts
@@ -1369,7 +1369,7 @@ You must name the rule in such manner that it&apos;ll be checked first, because 
     </message>
     <message>
         <location filename="../../../opensnitch/res/stats.ui" line="287"/>
-        <source>Save to CSV.</source>
+        <source>Save to CSV</source>
         <translation type="obsolete">CSVファイルに保存</translation>
     </message>
     <message>

--- a/ui/i18n/locales/lt_LT/opensnitch-lt_LT.ts
+++ b/ui/i18n/locales/lt_LT/opensnitch-lt_LT.ts
@@ -1463,7 +1463,7 @@ Taisyklę turite pavadinti taip, kad ji būtų tikrinama pirma, nes taisyklės t
     </message>
     <message>
         <location filename="../../../opensnitch/res/stats.ui" line="284"/>
-        <source>Save to CSV.</source>
+        <source>Save to CSV</source>
         <translation type="obsolete">Įrašyti į CSV.</translation>
     </message>
     <message>

--- a/ui/i18n/locales/nb_NO/opensnitch-nb_NO.ts
+++ b/ui/i18n/locales/nb_NO/opensnitch-nb_NO.ts
@@ -1311,7 +1311,7 @@ You must name the rule in such manner that it&apos;ll be checked first, because 
     </message>
     <message>
         <location filename="../../../opensnitch/res/stats.ui" line="287"/>
-        <source>Save to CSV.</source>
+        <source>Save to CSV</source>
         <translation type="obsolete">Lagre til CSV.</translation>
     </message>
     <message>

--- a/ui/i18n/locales/pt_BR/opensnitch-pt_BR.ts
+++ b/ui/i18n/locales/pt_BR/opensnitch-pt_BR.ts
@@ -1514,7 +1514,7 @@ Você deve nomear a regra de forma que ela seja verificada primeiro, porque eles
     </message>
     <message>
         <location filename="../../../opensnitch/res/stats.ui" line="287"/>
-        <source>Save to CSV.</source>
+        <source>Save to CSV</source>
         <translation type="obsolete">Salvar em CSV.</translation>
     </message>
     <message>

--- a/ui/i18n/locales/ro_RO/opensnitch-ro_RO.ts
+++ b/ui/i18n/locales/ro_RO/opensnitch-ro_RO.ts
@@ -1398,7 +1398,7 @@ You must name the rule in such manner that it'll be checked first, because they'
     </message>
     <message>
         <location filename="../../../opensnitch/res/stats.ui" line="105"/>
-        <source>Save to CSV.</source>
+        <source>Save to CSV</source>
         <translation type="obsolete">Salvează într-un fișier CSV.</translation>
     </message>
     <message>

--- a/ui/i18n/locales/ru_RU/opensnitch-ru_RU.ts
+++ b/ui/i18n/locales/ru_RU/opensnitch-ru_RU.ts
@@ -1473,7 +1473,7 @@ You must name the rule in such manner that it&apos;ll be checked first, because 
     </message>
     <message>
         <location filename="../../../opensnitch/res/stats.ui" line="284"/>
-        <source>Save to CSV.</source>
+        <source>Save to CSV</source>
         <translation type="obsolete">Сохранить в CSV.</translation>
     </message>
     <message>

--- a/ui/i18n/locales/tr_TR/opensnitch-tr_TR.ts
+++ b/ui/i18n/locales/tr_TR/opensnitch-tr_TR.ts
@@ -1481,7 +1481,7 @@ Alfabetik sıraya göre denetlendikleri için kuralı önce denetlenecek şekild
     </message>
     <message>
         <location filename="../../../opensnitch/res/stats.ui" line="284"/>
-        <source>Save to CSV.</source>
+        <source>Save to CSV</source>
         <translation type="obsolete">CSV olarak kaydet.</translation>
     </message>
     <message>

--- a/ui/opensnitch/database/__init__.py
+++ b/ui/opensnitch/database/__init__.py
@@ -209,7 +209,7 @@ class Database:
                 print("applying schema upgrade:", schema_version)
                 self._apply_db_upgrade("{0}/upgrade_{1}.sql".format(migrations_path, schema_version))
             except Exception:
-                print("Not applyging upgrade_{0}.sql".format(schema_version))
+                print("Not applying upgrade_{0}.sql".format(schema_version))
         self.set_schema_version(schema_version)
 
     def _apply_db_upgrade(self, file):


### PR DESCRIPTION
tooltips, by convention, look nicer without a terminal period; also, a typo was removed in some diagnostic text.