### PR TITLE
Wrap firewall errors in a common struct

### DIFF
--- a/daemon/firewall/common/common.go
+++ b/daemon/firewall/common/common.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -38,7 +39,22 @@ type (
 		FwEnabled       bool
 		sync.RWMutex
 	}
+	// FirewallError is a type that holds both IPv4 and IPv6 errors.
+	FirewallError struct {
+		Err4 error
+		Err6 error
+	}
 )
+
+// Error formats the errors for both IPv4 and IPv6 errors.
+func (e *FirewallError) Error() string {
+	return fmt.Sprintf("IPv4 error: %v, IPv6 error: %v", e.Err4, e.Err6)
+}
+
+// HasError simplifies error handling of the FirewallError type.
+func (e *FirewallError) HasError() bool {
+	return e.Err4 != nil || e.Err6 != nil
+}
 
 func (s *stopChecker) exit() <-chan bool {
 	s.RLock()

--- a/daemon/firewall/config/config.go
+++ b/daemon/firewall/config/config.go
@@ -5,7 +5,6 @@
 // The firewall rules defined by the user are reloaded in these cases:
 // - When the file system-fw.json changes.
 // - When the firewall rules are not present when listing them.
-//
 package config
 
 import (
@@ -20,30 +19,33 @@ import (
 // ExprValues holds the statements' options:
 // "Name": "ct",
 // "Values": [
-// {
-//   "Key":   "state",
-//   "Value": "established"
-// },
-// {
-//   "Key":   "state",
-//   "Value": "related"
-// }]
+//
+//	{
+//	  "Key":   "state",
+//	  "Value": "established"
+//	},
+//
+//	{
+//	  "Key":   "state",
+//	  "Value": "related"
+//	}]
 type ExprValues struct {
 	Key   string
 	Value string
 }
 
 // ExprStatement holds the definition of matches to use against connections.
-//{
-//	"Op": "!=",
-//	"Name": "tcp",
-//	"Values": [
-//		{
-//			"Key": "dport",
-// 			"Value": "443"
-//		}
-//	]
-//}
+//
+//	{
+//		"Op": "!=",
+//		"Name": "tcp",
+//		"Values": [
+//			{
+//				"Key": "dport",
+//				"Value": "443"
+//			}
+//		]
+//	}
 type ExprStatement struct {
 	Op     string        // ==, !=, ... Only one per expression set.
 	Name   string        // tcp, udp, ct, daddr, log, ...
@@ -163,7 +165,11 @@ func (c *Config) LoadDiskConfiguration(reload bool) {
 	c.loadConfiguration(raw)
 	// we need to monitor the configuration file for changes, regardless if it's
 	// malformed or not.
-	c.watcher.Remove(c.file)
+	err = c.watcher.Remove(c.file)
+	if err != nil {
+		log.Error("Failed to stop filesystem watcher: %v", err)
+		return
+	}
 	if err := c.watcher.Add(c.file); err != nil {
 		log.Error("Could not watch firewall configuration: %s", err)
 		return
@@ -223,6 +229,11 @@ func (c *Config) StopConfigWatcher() {
 
 	if c.watcher != nil {
 		c.watcher.Remove(c.file)
+		err := c.watcher.Remove(c.file)
+		if err != nil {
+			log.Error("Failed to stop filesystem watcher: %v", err)
+			return
+		}
 		c.watcher.Close()
 	}
 }

--- a/daemon/firewall/config/config.go
+++ b/daemon/firewall/config/config.go
@@ -5,6 +5,7 @@
 // The firewall rules defined by the user are reloaded in these cases:
 // - When the file system-fw.json changes.
 // - When the firewall rules are not present when listing them.
+//
 package config
 
 import (
@@ -19,33 +20,30 @@ import (
 // ExprValues holds the statements' options:
 // "Name": "ct",
 // "Values": [
-//
-//	{
-//	  "Key":   "state",
-//	  "Value": "established"
-//	},
-//
-//	{
-//	  "Key":   "state",
-//	  "Value": "related"
-//	}]
+// {
+//   "Key":   "state",
+//   "Value": "established"
+// },
+// {
+//   "Key":   "state",
+//   "Value": "related"
+// }]
 type ExprValues struct {
 	Key   string
 	Value string
 }
 
 // ExprStatement holds the definition of matches to use against connections.
-//
-//	{
-//		"Op": "!=",
-//		"Name": "tcp",
-//		"Values": [
-//			{
-//				"Key": "dport",
-//				"Value": "443"
-//			}
-//		]
-//	}
+//{
+//	"Op": "!=",
+//	"Name": "tcp",
+//	"Values": [
+//		{
+//			"Key": "dport",
+// 			"Value": "443"
+//		}
+//	]
+//}
 type ExprStatement struct {
 	Op     string        // ==, !=, ... Only one per expression set.
 	Name   string        // tcp, udp, ct, daddr, log, ...
@@ -165,11 +163,7 @@ func (c *Config) LoadDiskConfiguration(reload bool) {
 	c.loadConfiguration(raw)
 	// we need to monitor the configuration file for changes, regardless if it's
 	// malformed or not.
-	err = c.watcher.Remove(c.file)
-	if err != nil {
-		log.Error("Failed to stop filesystem watcher: %v", err)
-		return
-	}
+	c.watcher.Remove(c.file)
 	if err := c.watcher.Add(c.file); err != nil {
 		log.Error("Could not watch firewall configuration: %s", err)
 		return
@@ -229,11 +223,6 @@ func (c *Config) StopConfigWatcher() {
 
 	if c.watcher != nil {
 		c.watcher.Remove(c.file)
-		err := c.watcher.Remove(c.file)
-		if err != nil {
-			log.Error("Failed to stop filesystem watcher: %v", err)
-			return
-		}
 		c.watcher.Close()
 	}
 }

--- a/daemon/firewall/iptables/iptables.go
+++ b/daemon/firewall/iptables/iptables.go
@@ -140,10 +140,10 @@ func IsAvailable() error {
 
 // EnableInterception adds fw rules to intercept connections.
 func (ipt *Iptables) EnableInterception() {
-	if err4, err6 := ipt.QueueConnections(common.EnableRule, true); err4 != nil || err6 != nil {
-		log.Fatal("Error while running conntrack firewall rule: %s %s", err4, err6)
-	} else if err4, err6 = ipt.QueueDNSResponses(common.EnableRule, true); err4 != nil || err6 != nil {
-		log.Error("Error while running DNS firewall rule: %s %s", err4, err6)
+	if err := ipt.QueueConnections(common.EnableRule, true); err != nil {
+		log.Fatal("Error while running conntrack firewall rule: %s %s", err)
+	} else if err = ipt.QueueDNSResponses(common.EnableRule, true); err != nil {
+		log.Error("Error while running DNS firewall rule: %s %s", err)
 	}
 	// start monitoring firewall rules to intercept network traffic
 	ipt.NewRulesChecker(ipt.AreRulesLoaded, ipt.reloadRulesCallback)

--- a/daemon/firewall/iptables/rules.go
+++ b/daemon/firewall/iptables/rules.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 
 	"github.com/evilsocket/opensnitch/daemon/core"
+	"github.com/evilsocket/opensnitch/daemon/firewall/common"
 	"github.com/evilsocket/opensnitch/daemon/log"
 	"github.com/vishvananda/netlink"
 )
 
 // RunRule inserts or deletes a firewall rule.
-func (ipt *Iptables) RunRule(action Action, enable bool, logError bool, rule []string) (err4, err6 error) {
+func (ipt *Iptables) RunRule(action Action, enable bool, logError bool, rule []string) *common.FirewallError {
 	if enable == false {
 		action = "-D"
 	}
@@ -36,13 +37,13 @@ func (ipt *Iptables) RunRule(action Action, enable bool, logError bool, rule []s
 		}
 	}
 
-	return
+	return &common.FirewallError{Err4: err4, Err6: err6}
 }
 
 // QueueDNSResponses redirects DNS responses to us, in order to keep a cache
 // of resolved domains.
 // INPUT --protocol udp --sport 53 -j NFQUEUE --queue-num 0 --queue-bypass
-func (ipt *Iptables) QueueDNSResponses(enable bool, logError bool) (err4, err6 error) {
+func (ipt *Iptables) QueueDNSResponses(enable bool, logError bool) *common.FirewallError {
 	return ipt.RunRule(INSERT, enable, logError, []string{
 		"INPUT",
 		"--protocol", "udp",
@@ -56,8 +57,8 @@ func (ipt *Iptables) QueueDNSResponses(enable bool, logError bool) (err4, err6 e
 // QueueConnections inserts the firewall rule which redirects connections to us.
 // Connections are queued until the user denies/accept them, or reaches a timeout.
 // OUTPUT -t mangle -m conntrack --ctstate NEW,RELATED -j NFQUEUE --queue-num 0 --queue-bypass
-func (ipt *Iptables) QueueConnections(enable bool, logError bool) (error, error) {
-	err4, err6 := ipt.RunRule(ADD, enable, logError, []string{
+func (ipt *Iptables) QueueConnections(enable bool, logError bool) *common.FirewallError {
+	err := ipt.RunRule(ADD, enable, logError, []string{
 		"OUTPUT",
 		"-t", "mangle",
 		"-m", "conntrack",
@@ -73,5 +74,5 @@ func (ipt *Iptables) QueueConnections(enable bool, logError bool) (error, error)
 			log.Error("error in ConntrackTableFlush %s", err)
 		}
 	}
-	return err4, err6
+	return err
 }

--- a/daemon/firewall/iptables/system.go
+++ b/daemon/firewall/iptables/system.go
@@ -28,7 +28,7 @@ func (ipt *Iptables) CreateSystemRule(rule *config.FwRule, table, chain, hook st
 	ipt.RunRule(NEWCHAIN, common.EnableRule, logErrors, []string{chainName, "-t", table})
 
 	// Insert the rule at the top of the chain
-	if err4, err6 := ipt.RunRule(INSERT, common.EnableRule, logErrors, []string{hook, "-t", table, "-j", chainName}); err4 == nil && err6 == nil {
+	if err := ipt.RunRule(INSERT, common.EnableRule, logErrors, []string{hook, "-t", table, "-j", chainName}); err == nil {
 		ipt.chains.Rules[table+"-"+chainName] = &SystemRule{
 			Table: table,
 			Chain: chain,
@@ -102,7 +102,7 @@ func (ipt *Iptables) DeleteSystemRules(force, backupExistingChains, logErrors bo
 }
 
 // DeleteSystemRule deletes a new rule.
-func (ipt *Iptables) DeleteSystemRule(action Action, rule *config.FwRule, table, chain string, enable bool) (err4, err6 error) {
+func (ipt *Iptables) DeleteSystemRule(action Action, rule *config.FwRule, table, chain string, enable bool) *common.FirewallError {
 	chainName := SystemRulePrefix + "-" + chain
 	if table == "" {
 		table = "filter"
@@ -120,9 +120,9 @@ func (ipt *Iptables) DeleteSystemRule(action Action, rule *config.FwRule, table,
 }
 
 // AddSystemRule inserts a new rule.
-func (ipt *Iptables) AddSystemRule(action Action, rule *config.FwRule, table, chain string, enable bool) (err4, err6 error) {
+func (ipt *Iptables) AddSystemRule(action Action, rule *config.FwRule, table, chain string, enable bool) *common.FirewallError {
 	if rule == nil {
-		return nil, nil
+		return nil
 	}
 	ipt.RLock()
 	defer ipt.RUnlock()

--- a/daemon/firewall/nftables/nftables.go
+++ b/daemon/firewall/nftables/nftables.go
@@ -118,10 +118,10 @@ func (n *Nft) EnableInterception() {
 		return
 	}
 
-	if err, _ := n.QueueDNSResponses(true, true); err != nil {
+	if err := n.QueueDNSResponses(true, true); err != nil {
 		log.Error("Error while running DNS nftables rule: %s", err)
 	}
-	if err, _ := n.QueueConnections(true, true); err != nil {
+	if err := n.QueueConnections(true, true); err != nil {
 		log.Error("Error while running conntrack nftables rule: %s", err)
 	}
 	// start monitoring firewall rules to intercept network traffic.

--- a/daemon/firewall/nftables/rules.go
+++ b/daemon/firewall/nftables/rules.go
@@ -3,6 +3,7 @@ package nftables
 import (
 	"fmt"
 
+	"github.com/evilsocket/opensnitch/daemon/firewall/common"
 	"github.com/evilsocket/opensnitch/daemon/firewall/nftables/exprs"
 	"github.com/evilsocket/opensnitch/daemon/log"
 	"github.com/google/nftables"
@@ -16,9 +17,9 @@ import (
 // of resolved domains.
 // This rule must be added in top of the system rules, otherwise it may get bypassed.
 // nft insert rule ip filter input udp sport 53 queue num 0 bypass
-func (n *Nft) QueueDNSResponses(enable bool, logError bool) (error, error) {
+func (n *Nft) QueueDNSResponses(enable, logError bool) *common.FirewallError {
 	if n.conn == nil {
-		return nil, nil
+		return nil
 	}
 	families := []string{exprs.NFT_FAMILY_INET}
 	for _, fam := range families {
@@ -67,10 +68,10 @@ func (n *Nft) QueueDNSResponses(enable bool, logError bool) (error, error) {
 	}
 	// apply changes
 	if !n.Commit() {
-		return fmt.Errorf("Error adding DNS interception rules"), nil
+		return &common.FirewallError{Err4: fmt.Errorf("Error adding DNS interception rules"), Err6: nil}
 	}
 
-	return nil, nil
+	return nil
 }
 
 // QueueConnections inserts the firewall rule which redirects connections to us.
@@ -78,17 +79,17 @@ func (n *Nft) QueueDNSResponses(enable bool, logError bool) (error, error) {
 // This rule must be added at the end of all the other rules, that way we can add
 // rules above this one to exclude a service/app from being intercepted.
 // nft insert rule ip mangle OUTPUT ct state new queue num 0 bypass
-func (n *Nft) QueueConnections(enable bool, logError bool) (error, error) {
+func (n *Nft) QueueConnections(enable, logError bool) *common.FirewallError {
 	if n.conn == nil {
-		return nil, fmt.Errorf("nftables QueueConnections: netlink connection not active")
+		return &common.FirewallError{Err4: fmt.Errorf("nftables QueueConnections: netlink connection not active"), Err6: nil}
 	}
 	table := getTable(exprs.NFT_CHAIN_MANGLE, exprs.NFT_FAMILY_INET)
 	if table == nil {
-		return nil, fmt.Errorf("QueueConnections() Error getting table mangle-inet")
+		return &common.FirewallError{Err4: fmt.Errorf("QueueConnections() Error getting table mangle-inet"), Err6: nil}
 	}
 	chain := getChain(exprs.NFT_HOOK_OUTPUT, table)
 	if chain == nil {
-		return nil, fmt.Errorf("QueueConnections() Error getting outputChain: output-%s", table.Name)
+		return &common.FirewallError{Err4: fmt.Errorf("QueueConnections() Error getting outputChain: output-%s", table.Name), Err6: nil}
 	}
 
 	n.conn.AddRule(&nftables.Rule{
@@ -115,7 +116,7 @@ func (n *Nft) QueueConnections(enable bool, logError bool) (error, error) {
 	})
 	// apply changes
 	if !n.Commit() {
-		return fmt.Errorf("Error adding interception rule "), nil
+		return &common.FirewallError{Err4: fmt.Errorf("Error adding interception rule "), Err6: nil}
 	}
 
 	if enable {
@@ -126,7 +127,7 @@ func (n *Nft) QueueConnections(enable bool, logError bool) (error, error) {
 		}
 	}
 
-	return nil, nil
+	return nil
 }
 
 func (n *Nft) insertRule(chain, table, family string, position uint64, exprs *[]expr.Any) error {

--- a/daemon/firewall/nftables/system.go
+++ b/daemon/firewall/nftables/system.go
@@ -3,6 +3,7 @@ package nftables
 import (
 	"strings"
 
+	"github.com/evilsocket/opensnitch/daemon/firewall/common"
 	"github.com/evilsocket/opensnitch/daemon/firewall/config"
 	"github.com/evilsocket/opensnitch/daemon/firewall/iptables"
 	"github.com/evilsocket/opensnitch/daemon/firewall/nftables/exprs"
@@ -134,5 +135,5 @@ func (n *Nft) AddSystemRule(rule *config.FwRule, chain *config.FwChain) (err4, e
 		}
 	}
 
-	return nil, nil
+	return nil
 }

--- a/daemon/firewall/rules.go
+++ b/daemon/firewall/rules.go
@@ -22,8 +22,8 @@ type Firewall interface {
 
 	EnableInterception()
 	DisableInterception(bool)
-	QueueDNSResponses(bool, bool) (error, error)
-	QueueConnections(bool, bool) (error, error)
+	QueueDNSResponses(bool, bool) *common.FirewallError
+	QueueConnections(bool, bool) *common.FirewallError
 	CleanRules(bool)
 
 	AddSystemRules(bool, bool)


### PR DESCRIPTION
This allows a little bit of more flexibility since now there is only one return value instead of two. The underlying logic stays the same. 
Also unrelated, but I've noticed that you're not tracking go.sum. This isn't a good practice.