### PR TITLE
feat(daemon): add OpenRC script

### DIFF
--- a/daemon/opensnitchd-openrc
+++ b/daemon/opensnitchd-openrc
@@ -1,0 +1,36 @@
+#!/sbin/openrc-run
+# OpenSnitch firewall service
+
+depend() {
+    before net
+    after iptables ip6tables 
+    use logger
+    provide firewall
+}
+
+start_pre() {
+        /bin/mkdir -p /etc/opensnitchd/rules
+        /bin/chown -R root:root /etc/opensnitchd
+        /bin/chown root:root /var/log/opensnitchd.log
+        /bin/chmod -R 755 /etc/opensnitchd
+        /bin/chmod -R 0644 /etc/opensnitchd/rules
+        /bin/chmod 0600 /var/log/opensnitchd.log
+}
+
+start() {
+    ebegin "Starting application firewall"
+    # only if the verbose flag is not set (rc-service opensnitchd start -v)
+    if [ -z "$VERBOSE" ]; then
+        # redirect stdout and stderr to /dev/null
+        /usr/local/bin/opensnitchd -rules-path /etc/opensnitchd/rules -log-file /var/log/opensnitchd.log > /dev/null 2>&1 &
+    else
+        /usr/local/bin/opensnitchd -rules-path /etc/opensnitchd/rules -log-file /var/log/opensnitchd.log
+    fi
+    eend $?
+}
+
+stop() {
+    ebegin "Stopping application firewall"
+    /usr/bin/pkill -SIGINT opensnitchd 
+    eend $?
+}


### PR DESCRIPTION
this PR adds a very basic script that would allow to get opensnitchd running under OpenRC init system. I've managed to get it to "work" i.e. not to crash, under Alpine 3.17 with Linux6.2.8-0-edge x86_64, but I keep getting this error:
```
Error creating queue #0: Error binding to queue: operation not permitted
```
I've set it to run using proc instead of bpf, because I have a hardened kernel. I can try giving it a test run in a VM without bpf hardening (I assume docker won't do in this case...). 
After this is merged and this issue resolved (I'll try to tackle this by myself, but any help is appreciated), I'd like to then proceed to package the application's components into an APKBUILD, so that it can be easily installed on Alpine.