### PR TITLE
Add non-gui setting for gRPC server max_message_length.

### DIFF
--- a/ui/bin/opensnitch-ui
+++ b/ui/bin/opensnitch-ui
@@ -117,15 +117,14 @@ Examples:
     print("Using server address:", args.socket)
 
     maxmsglencfg = cfg.getSettings(Config.DEFAULT_SERVER_MAX_MESSAGE_LENGTH)
-    match maxmsglencfg:
-        case '4MiB':
-            maxmsglen = 4194304
-        case '8MiB':
-            maxmsglen = 8388608
-        case '16MiB':
-            maxmsglen = 16777216
-        case _:
-            maxmsglen = 4194304
+    if maxmsglencfg == '4MiB':
+        maxmsglen = 4194304
+    elif maxmsglencfg == '8MiB':
+        maxmsglen = 8388608
+    elif maxmsglencfg == '16MiB':
+        maxmsglen = 16777216
+    else:
+        maxmsglen = 4194304
 
     print("gRPC Max Message Length:", maxmsglencfg)
     print("                  Bytes:", maxmsglen)

--- a/ui/bin/opensnitch-ui
+++ b/ui/bin/opensnitch-ui
@@ -99,11 +99,11 @@ Examples:
     thm.load_theme(app)
 
     Utils.create_socket_dirs()
+    cfg = Config.get()
     if args.socket == None:
         # default
         args.socket = "unix:///tmp/osui.sock"
 
-        cfg = Config.get()
         addr = cfg.getSettings(Config.DEFAULT_SERVER_ADDR)
         if addr != None and addr != "":
             if addr.startswith("unix://"):
@@ -115,6 +115,20 @@ Examples:
                 args.socket = addr
 
     print("Using server address:", args.socket)
+
+    maxmsglencfg = cfg.getSettings(Config.DEFAULT_SERVER_MAX_MESSAGE_LENGTH)
+    match maxmsglencfg:
+        case '4MiB':
+            maxmsglen = 4194304
+        case '8MiB':
+            maxmsglen = 8388608
+        case '16MiB':
+            maxmsglen = 16777216
+        case _:
+            maxmsglen = 4194304
+
+    print("gRPC Max Message Length:", maxmsglencfg)
+    print("                  Bytes:", maxmsglen)
 
     service = UIService(app, on_exit)
     # @doc: https://grpc.github.io/grpc/python/grpc.html#server-object
@@ -128,6 +142,8 @@ Examples:
                              # there's no response.
                              ('grpc.keepalive_timeout_ms', 20000),
                              ('grpc.keepalive_permit_without_calls', True),
+                             ('grpc.max_send_message_length', maxmsglen),
+                             ('grpc.max_receive_message_length', maxmsglen),
                          ))
 
     add_UIServicer_to_server(service, server)

--- a/ui/opensnitch/config.py
+++ b/ui/opensnitch/config.py
@@ -102,6 +102,7 @@ class Config:
     DEFAULT_POPUP_ADVANCED_DSTPORT = "global/default_popup_advanced_dstport"
     DEFAULT_POPUP_ADVANCED_UID = "global/default_popup_advanced_uid"
     DEFAULT_SERVER_ADDR  = "global/server_address"
+    DEFAULT_SERVER_MAX_MESSAGE_LENGTH  = "global/server_max_message_length"
     DEFAULT_HIDE_SYSTRAY_WARN  = "global/hide_systray_warning"
     DEFAULT_DB_TYPE_KEY  = "database/type"
     DEFAULT_DB_FILE_KEY  = "database/file"


### PR DESCRIPTION
#### Description
**Thanks to everyone involved with this project!** It's maturing well. Here's my attempt to contribute.

This change adds a new option to settings.conf: `server_max_message_length` (`DEFAULT_SERVER_MAX_MESSAGE_LENGTH`) accepting the following options:
- _4MiB_ (default)
- _8MiB_
- _16MiB_

The values are strings matched to set the corresponding integer for server `grpc.max_send_message_length` & `grpc.max_receive_message_length`. I'm guessing that few have encountered this problem based on reported issues. I don't think that exposing a GUI option is warranted nor is granular control.

The default of _4MiB_ can be increased within **~/.config/opensnitch/settings.conf** by adding the following to `[global]`:
`server_max_message_length=8MiB`

#### Background
Archlinux Flatpak Steam _[Insurgency: Sandstorm](https://store.steampowered.com/app/581320/Insurgency_Sandstorm/)_ online gaming intermittently produces the following warnings:
_[2023-06-04 00:19:15]  WAR  Error while pinging UI service: rpc error: code = ResourceExhausted desc = Received message larger than max (4753069 vs. 4194304), state: READY
[2023-06-04 01:24:21]  WAR  Error while pinging UI service: rpc error: code = ResourceExhausted desc = Received message larger than max (4917273 vs. 4194304), state: READY
[2023-06-04 01:54:05]  WAR  Error while pinging UI service: rpc error: code = ResourceExhausted desc = Received message larger than max (4393013 vs. 4194304), state: READY_
Using 8MiB maximum I've been unable to reproduce the problem (yet).