### PR TITLE
Introduce 2 new daemon logging options: LogUTC & LogMicro.

### DIFF
--- a/daemon/default-config.json
+++ b/daemon/default-config.json
@@ -9,6 +9,8 @@
     "InterceptUnknown": false,
     "ProcMonitorMethod": "ebpf",
     "LogLevel": 2,
+    "LogUTC": true,
+    "LogMicro": false,
     "Firewall": "nftables",
     "Stats": {
         "MaxEvents": 150,

--- a/daemon/log/log.go
+++ b/daemon/log/log.go
@@ -49,6 +49,8 @@ var (
 	StdoutFile = "/dev/stdout"
 	DateFormat = "2006-01-02 15:04:05"
 	MinLevel   = INFO
+	LogUTC     = true
+	LogMicro   = false
 
 	mutex  = &sync.RWMutex{}
 	labels = map[int]string{
@@ -129,6 +131,36 @@ func GetLogLevel() int {
 	return MinLevel
 }
 
+// SetLogUTC configures UTC timestamps
+func SetLogUTC(newLogUTC bool) {
+        mutex.Lock()
+        defer mutex.Unlock()
+        LogUTC = newLogUTC
+}
+
+// GetLogUTC returns the current config.
+func GetLogUTC() bool {
+        mutex.Lock()
+        defer mutex.Unlock()
+
+        return LogUTC
+}
+
+// SetLogMicro configures microsecond timestamps
+func SetLogMicro(newLogMicro bool) {
+        mutex.Lock()
+        defer mutex.Unlock()
+        LogMicro = newLogMicro
+}
+
+// GetLogMicro returns the current config.
+func GetLogMicro() bool {
+        mutex.Lock()
+        defer mutex.Unlock()
+
+        return LogMicro
+}
+
 // Log prints out a text with the given color and format
 func Log(level int, format string, args ...interface{}) {
 	mutex.Lock()
@@ -136,7 +168,16 @@ func Log(level int, format string, args ...interface{}) {
 	if level >= MinLevel {
 		label := labels[level]
 		color := colors[level]
-		when := time.Now().UTC().Format(DateFormat)
+
+		datefmt := DateFormat
+
+		if LogMicro == true {
+			datefmt = DateFormat + ".000000"
+		}
+		when := time.Now().UTC().Format(datefmt)
+		if LogUTC == false {
+			when = time.Now().Local().Format(datefmt)
+		}
 
 		what := fmt.Sprintf(format, args...)
 		if strings.HasSuffix(what, "\n") == false {

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -58,6 +58,8 @@ var (
 	checkRequirements = false
 	procmonMethod     = ""
 	logFile           = ""
+	logUTC            = true
+	logMicro          = false
 	rulesPath         = "rules"
 	noLiveReload      = false
 	queueNum          = 0
@@ -101,6 +103,8 @@ func init() {
 	flag.BoolVar(&noLiveReload, "no-live-reload", debug, "Disable rules live reloading.")
 
 	flag.StringVar(&logFile, "log-file", logFile, "Write logs to this file instead of the standard output.")
+	flag.BoolVar(&logUTC, "log-utc", logUTC, "Write logs output with UTC timezone (enabled by default).")
+	flag.BoolVar(&logMicro, "log-micro", logMicro, "Write logs output with microsecond timestamp (disabled by default).")
 	flag.BoolVar(&debug, "debug", debug, "Enable debug level logs.")
 	flag.BoolVar(&warning, "warning", warning, "Enable warning level logs.")
 	flag.BoolVar(&important, "important", important, "Enable important level logs.")
@@ -111,7 +115,7 @@ func init() {
 }
 
 func overwriteLogging() bool {
-	return debug || warning || important || errorlog || logFile != ""
+	return debug || warning || important || errorlog || logFile != "" || logUTC || logMicro
 }
 
 func setupLogging() {
@@ -127,6 +131,9 @@ func setupLogging() {
 	} else {
 		log.SetLogLevel(log.INFO)
 	}
+
+	log.SetLogUTC(logUTC)
+	log.SetLogMicro(logMicro)
 
 	var logFileToUse string
 	if logFile == "" {

--- a/daemon/ui/client.go
+++ b/daemon/ui/client.go
@@ -48,6 +48,8 @@ type Config struct {
 	InterceptUnknown  bool                   `json:"InterceptUnknown"`
 	ProcMonitorMethod string                 `json:"ProcMonitorMethod"`
 	LogLevel          *uint32                `json:"LogLevel"`
+	LogUTC            bool                   `json:"LogUTC"`
+	LogMicro          bool                   `json:"LogMicro"`
 	Firewall          string                 `json:"Firewall"`
 	Stats             statistics.StatsConfig `json:"Stats"`
 }

--- a/daemon/ui/config.go
+++ b/daemon/ui/config.go
@@ -77,6 +77,8 @@ func (c *Client) loadConfiguration(rawConfig []byte) bool {
 	if config.LogLevel != nil {
 		log.SetLogLevel(int(*config.LogLevel))
 	}
+	log.SetLogUTC(config.LogUTC)
+	log.SetLogMicro(config.LogMicro)
 	if config.Server.LogFile != "" {
 		log.Close()
 		log.OpenFile(config.Server.LogFile)

--- a/ui/opensnitch/dialogs/preferences.py
+++ b/ui/opensnitch/dialogs/preferences.py
@@ -143,6 +143,8 @@ class PreferencesDialog(QtWidgets.QDialog, uic.loadUiType(DIALOG_UI_PATH)[0]):
         self.comboNodeMonitorMethod.currentIndexChanged.connect(self._cb_node_needs_update)
         self.comboNodeLogLevel.currentIndexChanged.connect(self._cb_node_needs_update)
         self.comboNodeLogFile.currentIndexChanged.connect(self._cb_node_needs_update)
+        self.checkNodeLogUTC.clicked.connect(self._cb_node_needs_update)
+        self.checkNodeLogMicro.clicked.connect(self._cb_node_needs_update)
         self.comboNodeAddress.currentTextChanged.connect(self._cb_node_needs_update)
         self.checkInterceptUnknown.clicked.connect(self._cb_node_needs_update)
         self.checkApplyToNodes.clicked.connect(self._cb_node_needs_update)
@@ -273,6 +275,8 @@ class PreferencesDialog(QtWidgets.QDialog, uic.loadUiType(DIALOG_UI_PATH)[0]):
                 self.comboNodeMonitorMethod.setCurrentText(node_config['ProcMonitorMethod'])
                 self.checkInterceptUnknown.setChecked(node_config['InterceptUnknown'])
                 self.comboNodeLogLevel.setCurrentIndex(int(node_config['LogLevel']))
+                self.checkNodeLogUTC.setChecked(node_config['LogUTC'])
+                self.checkNodeLogMicro.setChecked(node_config['LogMicro'])
 
                 if node_config.get('Server') != None:
                     self.comboNodeAddress.setEnabled(True)
@@ -306,6 +310,8 @@ class PreferencesDialog(QtWidgets.QDialog, uic.loadUiType(DIALOG_UI_PATH)[0]):
             node_config['DefaultDuration'] = node_duration
             node_config['ProcMonitorMethod'] = self.comboNodeMonitorMethod.currentText()
             node_config['LogLevel'] = self.comboNodeLogLevel.currentIndex()
+            node_config['LogUTC'] = self.checkNodeLogUTC.isChecked()
+            node_config['LogMicro'] = self.checkNodeLogMicro.isChecked()
             node_config['InterceptUnknown'] = self.checkInterceptUnknown.isChecked()
 
             if node_config.get('Server') != None:
@@ -351,6 +357,8 @@ class PreferencesDialog(QtWidgets.QDialog, uic.loadUiType(DIALOG_UI_PATH)[0]):
         self.comboNodeMonitorMethod.setCurrentIndex(0)
         self.checkInterceptUnknown.setChecked(False)
         self.comboNodeLogLevel.setCurrentIndex(0)
+        self.checkNodeLogUTC.setChecked(True)
+        self.checkNodeLogMicro.setChecked(False)
         self.labelNodeName.setText("")
         self.labelNodeVersion.setText("")
 

--- a/ui/opensnitch/res/preferences.ui
+++ b/ui/opensnitch/res/preferences.ui
@@ -857,6 +857,20 @@ Temporary rules will still be valid, and you can use them when prompted to allow
          </property>
         </widget>
        </item>
+       <item row="11" column="2">
+        <widget class="QCheckBox" name="checkNodeLogUTC">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="2">
+        <widget class="QCheckBox" name="checkNodeLogMicro">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
        <item row="7" column="0">
         <widget class="QLabel" name="label_11">
          <property name="toolTip">
@@ -999,6 +1013,26 @@ Temporary rules will still be valid, and you can use them when prompted to allow
          </property>
          <property name="text">
           <string>Debug invalid connections</string>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0">
+        <widget class="QLabel" name="label_22">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, OpenSnitch will use the UTC timezone for timestamps.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Log UTC timestamps</string>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="0">
+        <widget class="QLabel" name="label_23">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, OpenSnitch will log timestamp microseconds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Log timestamp microseconds</string>
          </property>
         </widget>
        </item>

--- a/ui/tests/dialogs/__init__.py
+++ b/ui/tests/dialogs/__init__.py
@@ -20,6 +20,8 @@ class ClientConfig:
     "InterceptUnknown": false,
     "ProcMonitorMethod": "ebpf",
     "LogLevel": 0,
+    "LogUTC": true,
+    "LogMicro": false,
     "Firewall": "iptables",
     "Stats": {
         "MaxEvents": 150,

--- a/ui/tests/dialogs/test_preferences.py
+++ b/ui/tests/dialogs/test_preferences.py
@@ -72,6 +72,8 @@ class TestPreferences():
         self.prefs.comboNodeAction.setCurrentIndex(Config.ACTION_ALLOW_IDX)
         self.prefs.comboNodeMonitorMethod.setCurrentIndex(2)
         self.prefs.comboNodeLogLevel.setCurrentIndex(5)
+        self.prefs.checkNodeLogUTC.setChecked(False)
+        self.prefs.checkNodeLogMicro.setChecked(True)
         self.prefs.checkInterceptUnknown.setChecked(True)
         self.prefs.tabWidget.setCurrentIndex(self.prefs.TAB_NODES)
         self.prefs._node_needs_update = True
@@ -84,6 +86,8 @@ class TestPreferences():
             assert conf['InterceptUnknown'] == True
             assert conf['ProcMonitorMethod'] == "audit"
             assert conf['LogLevel'] == 5
+            assert conf['LogUTC'] == False
+            assert conf['LogMicro'] == True
             assert conf['DefaultAction'] == "allow"
 
 # TODO: click on the QMessageDialog


### PR DESCRIPTION
This request adds two new options to configure the daemon logging:

- **LogUTC**: toggles `time.Now().UTC()` vs `time.Now().local()`
- **LogMicro**: enable microsecond timestamp

Both options are exposed within the UI.