### PR TITLE
use `uname -m` instead of the `arch` command

### DIFF
--- a/ebpf_prog/Makefile
+++ b/ebpf_prog/Makefile
@@ -8,7 +8,7 @@ KERNEL_HEADERS ?= /usr/src/linux-headers-$(shell uname -r)/
 CLANG ?= clang
 LLC ?= llc
 LLVM_STRIP ?= llvm-strip -g
-ARCH ?= $(shell arch)
+ARCH ?= $(shell uname -m)
 
 # as in /usr/src/linux-headers-*/arch/
 # TODO: extract correctly the archs, and add more if needed.


### PR DESCRIPTION
The `arch` command is deprecated on modern systems, and indeed, many distros do not provide it (one of those being Arch Linux, ironically). Since `uname` is already used in the Makefile, prefer its `-m` flag equivalent instead.