### PR TITLE
Allow starting in background when tray not available

### DIFF
--- a/ui/bin/opensnitch-ui
+++ b/ui/bin/opensnitch-ui
@@ -79,6 +79,7 @@ Examples:
     parser.add_argument("--max-clients", dest="serverWorkers", default=10, help="Max number of allowed clients (incoming connections).")
     parser.add_argument("--debug", dest="debug", action="store_true", help="Enable debug logs")
     parser.add_argument("--debug-grpc", dest="debug_grpc", action="store_true", help="Enable gRPC debug logs")
+    parser.add_argument("--background", dest="background", action="store_true", help="Start UI in background even, when tray is not available")
 
     args = parser.parse_args()
 
@@ -138,7 +139,7 @@ Examples:
 
         maxmsglen = cfg.getMaxMsgLength()
 
-        service = UIService(app, on_exit)
+        service = UIService(app, on_exit, start_in_bg=args.background)
         localserver.newConnection.connect(service.OpenWindow)
         # @doc: https://grpc.github.io/grpc/python/grpc.html#server-object
         server = grpc.server(futures.ThreadPoolExecutor(),

--- a/ui/bin/opensnitch-ui
+++ b/ui/bin/opensnitch-ui
@@ -22,6 +22,7 @@
 
 from PyQt5 import QtWidgets, QtCore
 from PyQt5.QtCore import QCoreApplication as QC
+from PyQt5.QtNetwork import QLocalServer, QLocalSocket
 
 import sys
 import os
@@ -37,6 +38,8 @@ dist_path = '/usr/lib/python3/dist-packages/'
 if dist_path not in sys.path:
     sys.path.append(dist_path)
 
+app_id = "io.github.evilsocket.opensnitch"
+
 from opensnitch.service import UIService
 from opensnitch.config import Config
 from opensnitch.utils import Themes, Utils, Versions, Message
@@ -47,7 +50,6 @@ from opensnitch import auth
 
 def on_exit():
     server.stop(0)
-    lockfile.unlock()
     app.quit()
     sys.exit(0)
 
@@ -100,15 +102,16 @@ Examples:
 
     try:
         app = QtWidgets.QApplication(sys.argv)
-        lockfile = QtCore.QLockFile(os.path.join(xdg_runtime_dir, 'osui.lock'))
 
-        if not lockfile.tryLock(100):
-            Message.ok(
-                QC.translate("stats", "Error"),
-                QC.translate("stats", "OpenSnitch UI is already running!"),
-                QtWidgets.QMessageBox.Warning
-            )
-            raise Exception("GUI already running, exiting.")
+        localsocket = QLocalSocket()
+        localsocket.connectToServer(app_id)
+
+        if localsocket.waitForConnected():
+            raise Exception("GUI already running, opening its window and exiting.")
+        else:
+            localserver = QLocalServer()
+            localserver.removeServer(app_id)
+            localserver.listen(app_id)
 
         if hasattr(QtCore.Qt, 'AA_UseHighDpiPixmaps'):
             app.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps, True)
@@ -136,6 +139,7 @@ Examples:
         maxmsglen = cfg.getMaxMsgLength()
 
         service = UIService(app, on_exit)
+        localserver.newConnection.connect(service.OpenWindow)
         # @doc: https://grpc.github.io/grpc/python/grpc.html#server-object
         server = grpc.server(futures.ThreadPoolExecutor(),
                                 options=(
@@ -192,5 +196,3 @@ Examples:
         on_exit()
     except Exception as e:
         print(e)
-    finally:
-        lockfile.unlock()

--- a/ui/opensnitch/service.py
+++ b/ui/opensnitch/service.py
@@ -41,7 +41,7 @@ class UIService(ui_pb2_grpc.UIServicer, QtWidgets.QGraphicsObject):
     # .desktop filename located under /usr/share/applications/
     DESKTOP_FILENAME = "opensnitch_ui.desktop"
 
-    def __init__(self, app, on_exit):
+    def __init__(self, app, on_exit, start_in_bg=False):
         super(UIService, self).__init__()
 
 
@@ -113,7 +113,8 @@ class UIService(ui_pb2_grpc.UIServicer, QtWidgets.QGraphicsObject):
                 'users':{}
                 }
 
-        self._show_gui_if_tray_not_available()
+        if not start_in_bg:
+            self._show_gui_if_tray_not_available()
 
         self._cleaner = None
         if self._cfg.getBool(Config.DEFAULT_DB_PURGE_OLDEST):
@@ -221,6 +222,7 @@ class UIService(ui_pb2_grpc.UIServicer, QtWidgets.QGraphicsObject):
         print("")
         print("WARNING: system tray not available. On GNOME you need the extension gnome-shell-extension-appindicator.")
         print("\tRead more:", Config.HELP_SYSTRAY_WARN)
+        print("\tIf you want to start OpenSnitch GUI in background even if tray not available, use --background argument.")
         print("")
 
         hide_msg = self._cfg.getBool(Config.DEFAULT_HIDE_SYSTRAY_WARN)

--- a/ui/opensnitch/service.py
+++ b/ui/opensnitch/service.py
@@ -881,3 +881,5 @@ class UIService(ui_pb2_grpc.UIServicer, QtWidgets.QGraphicsObject):
 
         return node_iter
 
+    def OpenWindow(self):
+        self._stats_dialog.show()


### PR DESCRIPTION
This PR adds `--background` command line argument that starts GUI in background even when tray not available and uses QLocalSocket and QLocalServer instead of lockfile (now it is possible to open window without starting new instance, using launcher in programs menu).

Please review this code, because I never used Qt.

This will fix issue #940.