### PR TITLE
Use temporary files instead of piping in ebpf Makefile

### DIFF
--- a/ebpf_prog/Makefile
+++ b/ebpf_prog/Makefile
@@ -8,7 +8,7 @@ KERNEL_HEADERS ?= /usr/src/linux-headers-$(shell uname -r)/
 CLANG ?= clang
 LLC ?= llc
 LLVM_STRIP ?= llvm-strip -g
-ARCH ?= $(shell arch)
+ARCH ?= $(shell uname -m)
 
 # as in /usr/src/linux-headers-*/arch/
 # TODO: extract correctly the archs, and add more if needed.
@@ -51,7 +51,9 @@ CLANG_FLAGS = -I. \
 all: $(BIN)
 
 %.o: %.c
-	$(CLANG) $(CLANG_FLAGS) -c $< -o - | \
-		$(LLC) -march=bpf -mcpu=generic -filetype=obj -o $@
+	$(CLANG) $(CLANG_FLAGS) -c $< -o $@.partial
+	$(LLC) -march=bpf -mcpu=generic -filetype=obj -o $@ $@.partial
+	rm -f $@.partial
+
 clean:
-	rm -f *.o
+	rm -f *.o *.partial


### PR DESCRIPTION
Currently, when compiling the eBPF module, in the Makefile, the output of `clang` is directly piped to `llc`. This is bad, because in this case, should `clang` fail, `llc` still runs, but produces faulty `.o` files. `make` never picks up on it and doesn't abort compilation - a success is reported across the board (apart from the `clang` log).

This patch removes the file and explicitly writes (and later deletes) `clang`'s output to a `.partial` file. This is later used as the input of `llc`.