### PR TITLE
Introduce Sqlite WAL journal mode

### DIFF
--- a/ui/opensnitch/config.py
+++ b/ui/opensnitch/config.py
@@ -105,11 +105,12 @@ class Config:
     DEFAULT_SERVER_ADDR  = "global/server_address"
     DEFAULT_SERVER_MAX_MESSAGE_LENGTH  = "global/server_max_message_length"
     DEFAULT_HIDE_SYSTRAY_WARN  = "global/hide_systray_warning"
-    DEFAULT_DB_TYPE_KEY  = "database/type"
-    DEFAULT_DB_FILE_KEY  = "database/file"
-    DEFAULT_DB_PURGE_OLDEST  = "database/purge_oldest"
-    DEFAULT_DB_MAX_DAYS  = "database/max_days"
-    DEFAULT_DB_PURGE_INTERVAL  = "database/purge_interval"
+    DEFAULT_DB_TYPE_KEY       = "database/type"
+    DEFAULT_DB_FILE_KEY       = "database/file"
+    DEFAULT_DB_PURGE_OLDEST   = "database/purge_oldest"
+    DEFAULT_DB_MAX_DAYS       = "database/max_days"
+    DEFAULT_DB_PURGE_INTERVAL = "database/purge_interval"
+    DEFAULT_DB_JRNL_WAL       = "database/jrnl_wal"
 
     DEFAULT_TIMEOUT = 30
 
@@ -169,6 +170,7 @@ class Config:
         if self.settings.value(self.DEFAULT_DB_TYPE_KEY) == None:
             self.setSettings(self.DEFAULT_DB_TYPE_KEY, Database.DB_TYPE_MEMORY)
             self.setSettings(self.DEFAULT_DB_FILE_KEY, Database.DB_IN_MEMORY)
+            self.setSettings(self.DEFAULT_DB_JRNL_WAL, Database.DB_JRNL_WAL)
 
         self.setRulesDurationFilter(
             self.getBool(self.DEFAULT_IGNORE_RULES),

--- a/ui/opensnitch/res/preferences.ui
+++ b/ui/opensnitch/res/preferences.ui
@@ -1916,6 +1916,16 @@ Temporary rules will still be valid, and you can use them when prompted to allow
            </property>
           </widget>
          </item>
+         <item row="2" column="0">
+          <widget class="QCheckBox" name="checkDBJrnlWal">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Enable DB Write-Ahead Logging (WAL)</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
       </layout>

--- a/ui/opensnitch/service.py
+++ b/ui/opensnitch/service.py
@@ -61,9 +61,11 @@ class UIService(ui_pb2_grpc.UIServicer, QtWidgets.QGraphicsObject):
         self._cfg = Config.init()
         self._db = Database.instance()
         db_file=self._cfg.getSettings(self._cfg.DEFAULT_DB_FILE_KEY)
+        db_jrnl_wal=self._cfg.getBool(Config.DEFAULT_DB_JRNL_WAL)
         db_status, db_error = self._db.initialize(
             dbtype=self._cfg.getInt(self._cfg.DEFAULT_DB_TYPE_KEY),
-            dbfile=db_file
+            dbfile=db_file,
+            dbjrnl_wal=db_jrnl_wal
         )
         if db_status is False:
             Message.ok(

--- a/ui/opensnitch/utils/__init__.py
+++ b/ui/opensnitch/utils/__init__.py
@@ -235,7 +235,8 @@ class CleanerTask(Thread):
         self.db = Database("db-cleaner-connection")
         self.db_status, db_error = self.db.initialize(
             dbtype=self._cfg.getInt(self._cfg.DEFAULT_DB_TYPE_KEY),
-            dbfile=self._cfg.getSettings(self._cfg.DEFAULT_DB_FILE_KEY)
+            dbfile=self._cfg.getSettings(self._cfg.DEFAULT_DB_FILE_KEY),
+            dbjrnl_wal=self._cfg.getBool(self._cfg.DEFAULT_DB_JRNL_WAL)
         )
 
     def run(self):


### PR DESCRIPTION
- Add [Write-Ahead Logging](https://www.sqlite.org/wal.html) option for file mode database
- Disable by default
- Migrate journal_mode and related `PRAGMA` statement handling from _create_tables() to new functions: get_journal_mode()/set_journal_mode()

This yields a significant reduction of constant IO writes on my systems when db file mode is enabled. 

Note that `PRAGMA synchronous = NORMAL` doesn't appear to activate properly. This problem occurs on master branch builds as well. Manual inspection of the db shows that synchronous always = FULL unless manually set directly but this warrants additional discussion elsewhere.

