### PR TITLE
Update Compilation.md

### DIFF
--- a/wiki/Compilation.md
+++ b/wiki/Compilation.md
@@ -2,11 +2,11 @@
 
 (tested on Debian Sid and Ubuntu 18 and 20. It may fail on other distributions.)
 
-Make sure you have a correctly configured **Go >= 1.15** environment, that the `$GOPATH` environment variable is defined and then:
+Make sure you have a correctly configured **Go >= 1.16** environment and then:
 
 ```bash
 # install dependencies
-sudo apt-get install git golang libnetfilter-queue-dev libpcap-dev protobuf-compiler python3-pip pyqt5-dev-tools qttools5-dev-tools qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools python3-pyqt5.qtsql python3-notify2
+sudo apt-get install git libnetfilter-queue-dev libpcap-dev protobuf-compiler python3-pip pyqt5-dev-tools qttools5-dev-tools qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools python3-pyqt5.qtsql python3-notify2
 
 go install google.golang.org/protobuf@latest
 go install google.golang.org/protobuf/cmd/protoc-gen-go@latest


### PR DESCRIPTION
I tried to compile from source and ran into some errors. This PR addresses those errors.

no need to `apt install golang` because it may install a version < 1.16. We already specify that the user must have a Golang env >= 1.16

With go 1.15 and
```
export GOPATH=$HOME/go
export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
```
when running 
`go install google.golang.org/protobuf@latest`
I was getting
`package google.golang.org/protobuf@latest: cannot use path@version syntax in GOPATH mode`

upgrading to Golang 1.16 gets rid of the error (and setting GOPATH before running `go install` is not needed anymore)