### PR TITLE
Fix SIGSEGV caused by uninitialized firewall and logger

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -596,7 +596,14 @@ func main() {
 
 	setupWorkers()
 	setupQueues()
-
+	if err = firewall.Init(
+		uiClient.GetFirewallType(),
+		cfg.FwOptions.ConfigPath,
+		cfg.FwOptions.MonitorInterval,
+		&queueNum); err != nil {
+		log.Warning("%s", err)
+		uiClient.SendWarningAlert(err)
+	}
 	// queue and firewall rules should be ready by now
 
 	uiClient.Connect()

--- a/daemon/ui/config_utils.go
+++ b/daemon/ui/config_utils.go
@@ -107,10 +107,10 @@ func (c *Client) reloadConfiguration(reload bool, newConfig config.Config) *moni
 		log.Debug("[config] reloading config.server.loggers")
 		c.loggers.Stop()
 		c.loggers.Load(newConfig.Server.Loggers)
-		c.stats.SetLoggers(c.loggers)
 	} else {
 		log.Debug("[config] config.server.loggers not changed")
 	}
+	c.stats.SetLoggers(c.loggers)
 
 	if !reflect.DeepEqual(newConfig.Stats, c.config.Stats) {
 		log.Debug("[config] reloading config.stats")


### PR DESCRIPTION
I compile opensnitch from git, and I got a journalctl backlog full of these today:
![image](https://github.com/evilsocket/opensnitch/assets/159669210/4be9e996-9750-4ee7-ab86-8c4b9e4110a6)
This seemed to be related to bc3209494524497566a72a973f5b9ce1df36e67f, and after restoring firewall.Init(), I got this:
![image](https://github.com/evilsocket/opensnitch/assets/159669210/f1d22fe1-c9fc-44fd-b09b-e010b8bb3d0a)
[This change](https://github.com/evilsocket/opensnitch/commit/0b67c1a429b7c155da50ef7056737c521cfb3c91#diff-b8e796a8bd84a7996ec85b5d42c6766c6e4cb40ef3f21869d914e66ed74f2d39R110) to daemon/ui/config_utils.go, where SetLoggers() is called, changes it to only call it on one branch, so that seemed to be where the null logger problem was introduced.

My change seems to work properly without issues, but I'm not a Go person so feel free to correct me.