### PR TITLE
Remove duplicate regex in system.go for -check-requirements

### DIFF
--- a/daemon/core/system.go
+++ b/daemon/core/system.go
@@ -86,7 +86,6 @@ func CheckSysRequirements() {
         "Regexps": [
             "CONFIG_KPROBES=y",
             "CONFIG_KPROBES_ON_FTRACE=y",
-            "CONFIG_KPROBES_ON_FTRACE=y",
             "CONFIG_HAVE_KPROBES=y",
             "CONFIG_HAVE_KPROBES_ON_FTRACE=y",
             "CONFIG_KPROBE_EVENTS=y"


### PR DESCRIPTION
This fixes a minor issue where the same line is displayed twice in `opensnitchd -check-requirements`:

```
Checking system requirements for kernel version 6.8.9-asahi
------------------------------------------------------------------------------

        Checking => CONFIG_KPROBES=y
        Checking => CONFIG_KPROBES_ON_FTRACE=y
         - KPROBES not fully supported by this kernel.
        Checking => CONFIG_KPROBES_ON_FTRACE=y
         - KPROBES not fully supported by this kernel.
```