### PR TITLE
chore(wiki): removed trailing whitespaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: protocol daemon/opensnitchd ui/resources_rc.py
 
 install:
-	@cd daemon && make install	
+	@cd daemon && make install
 	@cd ui && make install
 
 protocol:
@@ -26,20 +26,20 @@ run:
 	opensnitch-ui --socket unix:///tmp/osui.sock &
 	./daemon/opensnitchd -rules-path /etc/opensnitchd/rules -ui-socket unix:///tmp/osui.sock -cpu-profile cpu.profile -mem-profile mem.profile
 
-test: 
-	clear 
+test:
+	clear
 	make clean
 	clear
 	mkdir -p rules
-	make 
+	make
 	clear
 	make run
 
 adblocker:
-	clear 
+	clear
 	make clean
 	clear
-	make 
+	make
 	clear
 	python make_ads_rules.py
 	clear

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ In order to submit changes for the wiki, please follow these steps:
 
 3. Make necessary modifications to the files located in the wiki/ directory
 
-4. Create a pull request. 
+4. Create a pull request.

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -9,7 +9,7 @@ install:
 	@systemctl daemon-reload
 
 opensnitchd:
-	@go build -o opensnitchd . 
+	@go build -o opensnitchd .
 
 clean:
 	@rm -rf opensnitchd

--- a/debian/copyright
+++ b/debian/copyright
@@ -23,7 +23,7 @@ License: GPL-3.0
  details.
  .
  You should have received a copy of the GNU General Public
- License along with this program. If not,  If not, see 
+ License along with this program. If not,  If not, see
  http://www.gnu.org/licenses/.
  .
  On Debian systems, the full text of the GNU General Public

--- a/proto/ui.proto
+++ b/proto/ui.proto
@@ -110,7 +110,7 @@ message Notification {
     string serverName = 3;
     // CHANGE_CONFIG: 2, data: {"default_timeout": 1, ...}
     Action type = 4;
-    string data = 5;   
+    string data = 5;
     repeated Rule rules = 6;
 }
 

--- a/release.sh
+++ b/release.sh
@@ -4,7 +4,7 @@
 CURRENT_VERSION=$(cat daemon/core/version.go | grep Version | cut -d '"' -f 2)
 TO_UPDATE=(
     daemon/core/version.go
-    ui/version.py 
+    ui/version.py
 )
 
 echo -n "Current version is $CURRENT_VERSION, select new version: "

--- a/ui/LICENSE
+++ b/ui/LICENSE
@@ -20,7 +20,7 @@ License: GPL-3.0
  details.
  .
  You should have received a copy of the GNU General Public
- License along with this program. If not,  If not, see 
+ License along with this program. If not,  If not, see
  http://www.gnu.org/licenses/.
  .
  On Debian systems, the full text of the GNU General Public

--- a/ui/debian/copyright
+++ b/ui/debian/copyright
@@ -20,7 +20,7 @@ License: GPL-3.0
  details.
  .
  You should have received a copy of the GNU General Public
- License along with this program. If not,  If not, see 
+ License along with this program. If not,  If not, see
  http://www.gnu.org/licenses/.
  .
  On Debian systems, the full text of the GNU General Public

--- a/ui/i18n/locales/de_DE/opensnitch-de_DE.ts
+++ b/ui/i18n/locales/de_DE/opensnitch-de_DE.ts
@@ -666,9 +666,9 @@ Knoten an</translation>
     </message>
     <message>
         <location filename="../../../opensnitch/res/ruleseditor.ui" line="260"/>
-        <source>Commas or spaces are not allowed to specify multiple domains. 
+        <source>Commas or spaces are not allowed to specify multiple domains.
 
-Use regular expressions instead: 
+Use regular expressions instead:
 .*(opensnitch|duckduckgo).com
 .*\.google.com
 

--- a/ui/i18n/locales/es_ES/opensnitch-es_ES.ts
+++ b/ui/i18n/locales/es_ES/opensnitch-es_ES.ts
@@ -666,9 +666,9 @@ los nodos</translation>
     </message>
     <message>
         <location filename="../../../opensnitch/res/ruleseditor.ui" line="260"/>
-        <source>Commas or spaces are not allowed to specify multiple domains. 
+        <source>Commas or spaces are not allowed to specify multiple domains.
 
-Use regular expressions instead: 
+Use regular expressions instead:
 .*(opensnitch|duckduckgo).com
 .*\.google.com
 

--- a/ui/i18n/locales/eu_ES/opensnitch-eu_ES.ts
+++ b/ui/i18n/locales/eu_ES/opensnitch-eu_ES.ts
@@ -638,9 +638,9 @@
     </message>
     <message>
         <location filename="../../../opensnitch/res/ruleseditor.ui" line="260"/>
-        <source>Commas or spaces are not allowed to specify multiple domains. 
+        <source>Commas or spaces are not allowed to specify multiple domains.
 
-Use regular expressions instead: 
+Use regular expressions instead:
 .*(opensnitch|duckduckgo).com
 .*\.google.com
 

--- a/ui/i18n/locales/pt_BR/opensnitch-pt_BR.ts
+++ b/ui/i18n/locales/pt_BR/opensnitch-pt_BR.ts
@@ -653,9 +653,9 @@
     </message>
     <message>
         <location filename="../../../opensnitch/res/ruleseditor.ui" line="260"/>
-        <source>Commas or spaces are not allowed to specify multiple domains. 
+        <source>Commas or spaces are not allowed to specify multiple domains.
 
-Use regular expressions instead: 
+Use regular expressions instead:
 .*(opensnitch|duckduckgo).com
 .*\.google.com
 

--- a/ui/opensnitch-ui.spec
+++ b/ui/opensnitch-ui.spec
@@ -62,7 +62,7 @@ fi
 if [ $1 -eq 1 ]; then
     echo -e "\n You need to install 2 more packages:
         unicode_slugify and grpcio-tools.
-    
+
         pip3 install grpcio-tools
         pip3 install unicode_slugify
     "
@@ -83,7 +83,7 @@ if [ $1 -eq 0 ]; then
     done
 
     pkill -15 opensnitch-ui 2>/dev/null || true
-    
+
     echo ""
     echo "  Remember to uninstall grpcio-tools and unicode_slugify if you don't"
     echo "  need them anymore:"

--- a/ui/opensnitch/customwidgets.py
+++ b/ui/opensnitch/customwidgets.py
@@ -15,7 +15,7 @@ class ColorizedDelegate(Qt.QItemDelegate):
     def paint(self, painter, option, index):
         if not index.isValid():
             return super().paint(painter, option, index)
-        
+
         nocolor=True
 
         value = index.data(QtCore.Qt.DisplayRole)
@@ -41,7 +41,7 @@ class ColorizedQSqlQueryModel(QSqlQueryModel):
         model=CustomQSqlQueryModel(
             modelData=
                 {
-                'colorize': 
+                'colorize':
                       {'offline': (QColor(QtCore.Qt.red), 2)},
                 'alignment': { Qt.AlignLeft, 2 }
                 }
@@ -89,16 +89,16 @@ class ConnectionsTableModel(QStandardItemModel):
     db = None
     #original query string before we modify it
     origQueryStr = QSqlQuery()
-    #modified query object 
+    #modified query object
     realQuery = QSqlQuery()
     #previous original query string; used to check if the query has changed
     prevQueryStr = ''
     #whether or not the original query has a filter (a WHERE condition)
     isQueryFilter = False
     limit = None
- 
+
     #a map for fast lookup or rows when filter is enabled
-    #contains ranges of rowids and count of filter hits 
+    #contains ranges of rowids and count of filter hits
     #range format {'from': <rowid>, 'to': <rowid>, 'hits':<int>}
     #including the 'from' rowid up to but NOT including the 'to' rowid
     map = []
@@ -142,7 +142,7 @@ class ConnectionsTableModel(QStandardItemModel):
         self.updateDistinctIfNeeded()
         self.limit = int(q.split(' ')[-1]) if q.split(' ')[-2] == 'LIMIT' else None
         self.isQueryFilter = True if ("LIKE '%" in q and "LIKE '% %'" not in q) or 'Action = "' in q else False
-        
+
         self.realQuery = QSqlQuery(db)
         isTotalRowCountChanged = False
         isQueryChanged = False
@@ -160,7 +160,7 @@ class ConnectionsTableModel(QStandardItemModel):
                 self.realQuery.setForwardOnly(True)
                 for offset in range(0, newRowsCount, self.rangeSize):
                     lowerBound = largestRowIdInMap + offset
-                    upperBound = min(lowerBound + self.rangeSize, self.maxRowId) 
+                    upperBound = min(lowerBound + self.rangeSize, self.maxRowId)
                     part1, part2 = q.split('ORDER')
                     qStr = part1 + 'AND rowid>'+ str(lowerBound) + ' AND rowid<=' + str(upperBound) + ' ORDER' + part2
                     self.realQuery.exec(qStr)
@@ -205,8 +205,8 @@ class ConnectionsTableModel(QStandardItemModel):
         #we only want to know the count of matching rows
         qStr = "SELECT COUNT(*) from connections WHERE (rowid> :lowerBound AND rowid<= :upperBound)"
         if actionStr:
-            qStr += ' AND ' + actionStr 
-        matchStr = self.getMatch(filterStr) if filterStr else None 
+            qStr += ' AND ' + actionStr
+        matchStr = self.getMatch(filterStr) if filterStr else None
         if matchStr:
             qStr += ' AND ' + matchStr
         qStr += ' LIMIT ' + str(self.limit) if self.limit else ''
@@ -242,7 +242,7 @@ class ConnectionsTableModel(QStandardItemModel):
         q = QSqlQuery(self.db)
         q.setForwardOnly(True)
         for column in self.distinct.keys():
-            q.exec('SELECT DISTINCT ' + column + ' FROM connections WHERE rowid>' 
+            q.exec('SELECT DISTINCT ' + column + ' FROM connections WHERE rowid>'
             + str(self.distinctLastRowId) + ' AND rowid<=' + str(self.maxRowId))
             while q.next():
                 if q.value(0) not in self.distinct[column]:
@@ -267,7 +267,7 @@ class ConnectionsTableModel(QStandardItemModel):
             qStr = self.origQueryStr.split('WHERE')[0] + ' WHERE '
             actionStr = self.getActionStr()
             if actionStr:
-                qStr += actionStr + " AND " 
+                qStr += actionStr + " AND "
             #find inside the map the range(s) in which top and bottom rows are located
             total, offsetInRange, botRowFound, topRowFound = 0, None, False, False
             ranges = [{'from':0, 'to':0, 'hits':0}]
@@ -275,7 +275,7 @@ class ConnectionsTableModel(QStandardItemModel):
                 if total + i['hits'] >= botRowNo:
                     botRowFound = True
                 if total + i['hits'] >= topRowNo:
-                    topRowFound = True                    
+                    topRowFound = True
                 if botRowFound and i['hits'] > 0:
                     if i['to'] == ranges[-1]['from']:
                         #merge two adjacent ranges
@@ -296,14 +296,14 @@ class ConnectionsTableModel(QStandardItemModel):
                 rangeStr = rangeStr[:-3] #remove trailing 'OR '
                 rangeStr += ') AND '
             qStr += rangeStr
-            
+
             filterStr = self.getFilterStr()
-            matchStr = self.getMatch(filterStr) if filterStr else None 
+            matchStr = self.getMatch(filterStr) if filterStr else None
             if matchStr:
                 qStr += matchStr + " AND "
             qStr = qStr[:-4] #remove trailing ' AND'
             qStr += ' ORDER '+ self.origQueryStr.split('ORDER')[1]
-        
+
         q.exec(qStr)
         q.last()
         rowsFound = max(0, q.at()+1)
@@ -311,8 +311,8 @@ class ConnectionsTableModel(QStandardItemModel):
             q.seek(QSql.BeforeFirstRow)
         else:
             #position the db cursor on topRowNo
-            q.seek(QSql.BeforeFirstRow if offsetInRange == 0 else offsetInRange-1) 
-        upperBound = min(maxRowsInViewport, rowsFound)       
+            q.seek(QSql.BeforeFirstRow if offsetInRange == 0 else offsetInRange-1)
+        upperBound = min(maxRowsInViewport, rowsFound)
         self.setRowCount(upperBound)
         #only visible rows will be filled with data
         if upperBound > 0:
@@ -324,7 +324,7 @@ class ConnectionsTableModel(QStandardItemModel):
                     self.setItem(x, col, QStandardItem(q.value(col)))
             self.blockSignals(False)
             self.dataChanged.emit(self.createIndex(0,0), self.createIndex(upperBound, len(self.headerLabels)))
-       
+
     #form a condition string for the query: if filterStr is (partially) present in any of the columns
     def getMatch (self, filterStr):
         match = {}
@@ -335,7 +335,7 @@ class ConnectionsTableModel(QStandardItemModel):
                     match[column].append(value)
         matchStr = None
         if any([match[col] for col in match]):
-            matchStr = '( ' 
+            matchStr = '( '
             if match['process']:
                 matchStr += "process IN ('" + "','".join(match['process']) + "') OR"
             if match['dst_host']:
@@ -385,7 +385,7 @@ class ConnectionsTableModel(QStandardItemModel):
         return rows
 
 class ConnectionsTableView(QTableView):
-    # how many rows can potentially be displayed in viewport 
+    # how many rows can potentially be displayed in viewport
     # the actual number of rows currently displayed may be less than this
     maxRowsInViewport = 0
     #vertical scroll bar
@@ -400,7 +400,7 @@ class ConnectionsTableView(QTableView):
         self.horizontalHeader().setStretchLastSection(True)
         #the built-in vertical scrollBar of this view is always off
         self.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
-       
+
     def setVerticalScrollBar(self, vScrollBar):
         self.vScrollBar = vScrollBar
         self.vScrollBar.valueChanged.connect(self.onValueChanged)
@@ -418,7 +418,7 @@ class ConnectionsTableView(QTableView):
     #stretch the bottom row; we don't want partial-height rows at the bottom
     #this will only trigger if rowCount value was changed
     def onRowsInsertedOrRemoved(self, parent, start, end):
-        if self.model().rowCount() == self.maxRowsInViewport:      
+        if self.model().rowCount() == self.maxRowsInViewport:
             self.verticalHeader().setStretchLastSection(True)
         else:
             self.verticalHeader().setStretchLastSection(False)
@@ -428,7 +428,7 @@ class ConnectionsTableView(QTableView):
         #refresh the viewport data based on new geometry
         self.calculateRowsInViewport()
         self.model().setRowCount(min(self.maxRowsInViewport, self.model().totalRowCount))
-        self.model().refreshViewport(self.vScrollBar.value(), self.maxRowsInViewport)  
+        self.model().refreshViewport(self.vScrollBar.value(), self.maxRowsInViewport)
 
     def calculateRowsInViewport(self):
         rowHeight = self.verticalHeader().defaultSectionSize()
@@ -437,14 +437,14 @@ class ConnectionsTableView(QTableView):
 
     def onValueChanged(self, vSBNewValue):
         savedIndex = self.selectionModel().currentIndex()
-        self.model().refreshViewport(vSBNewValue, self.maxRowsInViewport)  
-        #restore selection which was removed by model's refreshing the data 
+        self.model().refreshViewport(vSBNewValue, self.maxRowsInViewport)
+        #restore selection which was removed by model's refreshing the data
         self.selectionModel().setCurrentIndex(savedIndex, QItemSelectionModel.Rows | QItemSelectionModel.SelectCurrent)
 
     # if ( scrollbar at the top or row limit set):
     #   let new rows "push down" older rows without changing the scrollbar position
     # else:
-    #   don't update data in viewport, only change scrollbar position.      
+    #   don't update data in viewport, only change scrollbar position.
     def onRowCountChanged(self):
         totalCount = self.model().totalRowCount
         scrollBar = self.vScrollBar
@@ -455,16 +455,16 @@ class ConnectionsTableView(QTableView):
             scrollBar.setMinimum(0)
             scrollBar.setMaximum( min(totalCount, self.model().limit) - self.maxRowsInViewport)
             if scrollBarValue != newValue:
-                #setValue does not trigger valueChanged if new value is the same as old 
+                #setValue does not trigger valueChanged if new value is the same as old
                 scrollBar.setValue(newValue)
             else:
-                scrollBar.valueChanged.emit(newValue)  
+                scrollBar.valueChanged.emit(newValue)
         else:
-            scrollBar.setMinimum(0) 
+            scrollBar.setMinimum(0)
             scrollBar.setMaximum(max(0, totalCount - self.maxRowsInViewport))
             if scrollBarValue == 0:
-                scrollBar.valueChanged.emit(0)  
-            elif scrollBarValue > 0: 
+                scrollBar.valueChanged.emit(0)
+            elif scrollBarValue > 0:
                 if self.model().prependedRowCount == 0:
                     scrollBar.valueChanged.emit(scrollBarValue)
                 else:
@@ -480,11 +480,11 @@ class ConnectionsTableView(QTableView):
 
     def onKeyHome(self):
         self.vScrollBar.setValue(0)
-        self.selectionModel().setCurrentIndex(self.model().createIndex(0, 0), QItemSelectionModel.Rows | QItemSelectionModel.SelectCurrent)  
+        self.selectionModel().setCurrentIndex(self.model().createIndex(0, 0), QItemSelectionModel.Rows | QItemSelectionModel.SelectCurrent)
 
     def onKeyEnd(self):
         self.vScrollBar.setValue(self.vScrollBar.maximum())
-        self.selectionModel().setCurrentIndex(self.model().createIndex(min(self.maxRowsInViewport, self.model().totalRowCount) - 1, 0), QItemSelectionModel.Rows | QItemSelectionModel.SelectCurrent) 
+        self.selectionModel().setCurrentIndex(self.model().createIndex(min(self.maxRowsInViewport, self.model().totalRowCount) - 1, 0), QItemSelectionModel.Rows | QItemSelectionModel.SelectCurrent)
 
     def onKeyPageUp(self):
         #scroll up only when on the first row

--- a/ui/opensnitch/desktop_parser.py
+++ b/ui/opensnitch/desktop_parser.py
@@ -53,7 +53,7 @@ class LinuxDesktopParser(threading.Thread):
                 if os.path.exists(filename):
                     cmd = filename
                     break
-        
+
         return cmd
 
     def _discover_app_icon(self, app_name):

--- a/ui/opensnitch/res/ruleseditor.ui
+++ b/ui/opensnitch/res/ruleseditor.ui
@@ -257,9 +257,9 @@
          <bool>false</bool>
         </property>
         <property name="toolTip">
-         <string>Commas or spaces are not allowed to specify multiple domains. 
+         <string>Commas or spaces are not allowed to specify multiple domains.
 
-Use regular expressions instead: 
+Use regular expressions instead:
 .*(opensnitch|duckduckgo).com
 .*\.google.com
 

--- a/ui/setup.py
+++ b/ui/setup.py
@@ -7,7 +7,7 @@ path = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(path)
 
 from opensnitch.version import version
-        
+
 setup(name='opensnitch-ui',
       version=version,
       description='Prompt service and UI for the opensnitch application firewall.',

--- a/wiki/Compilation.md
+++ b/wiki/Compilation.md
@@ -18,7 +18,7 @@ export PATH=$PATH:$GOPATH/bin
 # You can try to install them with: sudo apt install python3-grpcio python3-protobuf
 python3 -m pip install --user grpcio-tools qt-material
 
-# clone the repository 
+# clone the repository
 git clone https://github.com/evilsocket/opensnitch
 cd opensnitch
 
@@ -41,7 +41,7 @@ Then it should build properly.
 
 ***Note for Ubuntu 22.xx users***
 
-You may need to install `qttols5-dev` package and set and environment variable:
+You may need to install `qttools5-dev` package and set and environment variable:
 
 ```
 #set env var for QT version
@@ -57,12 +57,12 @@ More info: [#773](https://github.com/evilsocket/opensnitch/issues/773)
 
 Follow the instructions described here: https://github.com/evilsocket/opensnitch/tree/master/ebpf_prog
 
-Additionally, you can use this script to easyly build the modules: 
+Additionally, you can use this script to easyly build the modules:
 https://github.com/evilsocket/opensnitch/blob/master/utils/packaging/build_modules.sh
 
 **Daemon**
 
-The `daemon` is implemented in Go and needs to run as root in order to interact with the Netfilter packet queue, edit 
+The `daemon` is implemented in Go and needs to run as root in order to interact with the Netfilter packet queue, edit
 iptables rules and so on, in order to compile it you will need to install the `protobuf-compiler`, `libpcap-dev` and `libnetfilter-queue-dev`
 packages on your system, then just:
 
@@ -105,7 +105,7 @@ This will install the `opensnitch-ui` command on your system (you can auto start
     sudo apt install locales
     sudo locale-gen en_US.UTF-8
     export LC_CTYPE=en_US.UTF-8
-    
+
 
 
 ***

--- a/wiki/Configurations.md
+++ b/wiki/Configurations.md
@@ -9,7 +9,7 @@ The file _/etc/opensnitchd/default-config.json_ holds the daemon configuration:
       "LogFile": "/var/log/opensnitchd.log"
       "Authentication": {},
       "Loggers": {}
-  }, 
+  },
   "DefaultAction": "deny",
   "DefaultDuration": "once",
   "InterceptUnknown": true,
@@ -104,7 +104,7 @@ On latest v.1.6.x version, you can change it to unix:///run/user/1000/opensnitch
 Use `--socket "[::]:50051"` to have the UI use TCP instead of a Unix socket and run the daemon on another computer with `-ui-socket "x.x.x.x:50051"` (where x.x.x.x is the IP of the computer running the UI service).
 
 Remote Daemon-Only Hosts:
- 
+
 `# /usr/bin/opensnitchd -rules-path /etc/opensnitchd/rules -ui-socket x.x.x.x:50051`
 
 Central GUI Host:

--- a/wiki/Cross-compilation.md
+++ b/wiki/Cross-compilation.md
@@ -5,7 +5,7 @@ The following steps are for compile OpenSnitch on _Debian testing_ for armhf. Yo
 ```
 $ sudo dpkg --add-architecture armhf
 $ sudo apt update
-$ sudo apt install libnetfilter-queue-dev:armhf libmnl-dev:armhf 
+$ sudo apt install libnetfilter-queue-dev:armhf libmnl-dev:armhf
 $ sudo apt install gcc-8-arm-linux-gnueabihf gcc-8-arm-linux-gnueabihf-base gcc-8-plugin-dev-arm-linux-gnueabi gcc-arm-linux-gnueabi
 
 $ export CC=arm-linux-gnueabi-gcc
@@ -21,7 +21,7 @@ Discussion regarding running the daemon on arm64: [#18](https://github.com/gusta
 $ sudo dpkg --add-architecture arm64
 $ sudo apt update
 $ sudo apt install libnetfilter-queue-dev:arm64 libmnl-dev:arm64
-$ apt install gccgo-aarch64-linux-gnu 
+$ apt install gccgo-aarch64-linux-gnu
 $ export CC=aarch64-linux-gnu-gcc
 $ export CGO_LDFLAGS="-L/usr/lib/aarch64-linux-gnu/"
 $ GOOS=linux GOARCH=arm64 CGO_ENABLED=1 PKG_CONFIG_PATH="/usr/lib/aarch64-linux-gnu/pkgconfig/"  go build -o opensnitchd-arm64 .

--- a/wiki/Dependencies-and-how-it-works.md
+++ b/wiki/Dependencies-and-how-it-works.md
@@ -28,7 +28,7 @@ will fail with an error (visible on the Preferences dialog).
 # Interaction with other software:
 
 **1. You don't need to turn off or uninstall other firewalling.**
-OpenSnitch doesn't turn them off, nor delete their rules. 
+OpenSnitch doesn't turn them off, nor delete their rules.
 
 If iptables is used: OpenSnitch's main rules are added to the default filter table,
 INPUT chain (`iptables -L INPUT`) and mangle table, OUTPUT chain (`iptables -t mangle -L OUTPUT`).

--- a/wiki/FAQs.md
+++ b/wiki/FAQs.md
@@ -24,11 +24,11 @@ Connections
 
 Be sure that the daemon is running: `$ pgrep opensnitchd`
 
-If it's not running, you may need to enable and start it: 
+If it's not running, you may need to enable and start it:
 
 ```
 $ sudo systemctl enable opensnitchd
-$ sudo systemctl start opensnitchd.service 
+$ sudo systemctl start opensnitchd.service
 ```
 
 #### No rules shown in the UI
@@ -64,7 +64,7 @@ Kernels support
 
 Your kernel needs some features to be enabled in order eBPF to work: debugfs (or tracefs), kprobes, perf events, ftrace and syscalls (bpf and ftrace).
 
-Since version 1.6.x you can execute the following command to know if your kernel has all the expected features: 
+Since version 1.6.x you can execute the following command to know if your kernel has all the expected features:
 
 `opensnitchd -check-requirements`
 
@@ -116,7 +116,7 @@ So if you want to prioritize some rules over others:
 2. [x] Priority field checked (Action: allow)
 3. OR Action: deny (not need to check the Priority field in these rules)
 
-More info: 
+More info:
   - https://github.com/evilsocket/opensnitch/wiki/Rules-examples
   - https://github.com/evilsocket/opensnitch/wiki/Rules#best-practices
 
@@ -124,7 +124,7 @@ More info:
 
 No. You only allow program A to access the net. Any other program launched by program A will be stopped until you allow or deny it.
 
-See some examples: 
+See some examples:
  - Spotify launching wget: https://github.com/evilsocket/opensnitch/discussions/401
  - Vivaldi browser deb package trying to install from the internet additional packages: https://github.com/evilsocket/opensnitch/discussions/742
 

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -14,11 +14,11 @@
 
 yum:
 
-> $ sudo yum localinstall opensnitch-\*.rpm; sudo yum localinstall opensnitch-ui\*.rpm 
+> $ sudo yum localinstall opensnitch-\*.rpm; sudo yum localinstall opensnitch-ui\*.rpm
 
 dnf:
 
-> $ sudo dnf install ./opensnitch-\*.rpm ./opensnitch-ui-\*.rpm 
+> $ sudo dnf install ./opensnitch-\*.rpm ./opensnitch-ui-\*.rpm
 
 (You can also double-click on the downloaded files)
 
@@ -52,7 +52,7 @@ This packages are provided to you in the aim of being useful and ease the instal
 
 ---
 
-The reason for installing some dependencies using `pip` is that they are not always packaged in all distributions and all versions (`python3-grpcio` on Ubuntu is only available from >= 19.x). Moreover, Ubuntu 20.04 `python3-grpcio` (version 1.16.1) differs from official 1.16.x that causes some working problems. 
+The reason for installing some dependencies using `pip` is that they are not always packaged in all distributions and all versions (`python3-grpcio` on Ubuntu is only available from >= 19.x). Moreover, Ubuntu 20.04 `python3-grpcio` (version 1.16.1) differs from official 1.16.x that causes some working problems.
 
 **Besides, grpc packages distributed with some distributions (python3-grpcio, OpenSuse) do not work.**
 
@@ -84,13 +84,13 @@ Select the right package for your architecture: `$(uname -m) == x86_64` -> opens
    - Pop!_OS
    - MX Linux 19.x
    - PureOS (Librem5)
- 
+
  * UI ([v1.4.0rc2](https://github.com/evilsocket/opensnitch/releases)):
    - Debian >= 9
    - Ubuntu >= 16.x
    - Fedora >= 29
    - OpenSuse Tumbleweed 15.3
-   - LinuxMint >= 18 
+   - LinuxMint >= 18
    - MX Linux 19.x
    - Pop!_OS
    - PureOS (Librem5)

--- a/wiki/Nodes-authentication.md
+++ b/wiki/Nodes-authentication.md
@@ -35,7 +35,7 @@ There are 2 options to verify how gRPC validates credentials:
 
 You can also use the server public certificate to authenticate all nodes, by replacing `"CACert"` with `"ServerCert"`:
     `"ServerCert": "/etc/opensnitchd/certs/server-cert.pem",`
- 
+
 'tls-mutual' configuration example:
 ```json
     "Server": {

--- a/wiki/Nodes.md
+++ b/wiki/Nodes.md
@@ -1,7 +1,7 @@
 A node is a daemon running on a machine. You can install the daemon on multiple machines, and manage them from the server (i.e.:GUI).
 
-> ℹ️ Note: if you want to install **only** the daemon from the Debian repositories, you'll have to execute this command: 
-> 
+> ℹ️ Note: if you want to install **only** the daemon from the Debian repositories, you'll have to execute this command:
+>
 > `$ sudo apt install --no-install-recommends opensnitch` (otherwise it'll install both, the daemon and the GUI)
 
 ![image](https://user-images.githubusercontent.com/2742953/197076010-2502855a-cdae-4f03-90bc-7a715efbbf64.png)

--- a/wiki/Rules-editor.md
+++ b/wiki/Rules-editor.md
@@ -21,7 +21,7 @@ Each field can be literal or a regex expression.
 
 Some examples:
 
-- Filtering by multiple ports: 
+- Filtering by multiple ports:
 
     `[x] To this port: ^(53|80|443)$`
 
@@ -33,10 +33,10 @@ Some examples:
 
 - Filtering by an exact domain, and nothing else: `[x] To this host: github.com` (will match only github.com, not www.github.com, etc)
 - Filtering by a domain and its subdomains: `[x] To this host: .*\.github.com`
-- Filtering an executable path: 
+- Filtering an executable path:
 
     `[x] From this executable: /usr/bin/python3`
-     
+
     (warning: /usr/bin/python3.6/3.7/3.8/etc won't match this rule)
 
 - Allow common system commands:
@@ -62,7 +62,7 @@ Some examples:
      Case insensitive rules:
 
     `[x] From this executable: (?i:.*ping)`
-     
+
      ![](https://user-images.githubusercontent.com/2742953/85209253-aa994a00-b336-11ea-87d9-a7a650510b6b.png)
 
 - Filtering LAN IPs or multiple ranges:

--- a/wiki/Rules-examples.md
+++ b/wiki/Rules-examples.md
@@ -50,7 +50,7 @@ targets ports 5551, 5552, 5553, 5554 OR 5555.
 ---
 
 `  [x] From this executable: /usr/bin/python3`
-     
+
 (warning: /usr/bin/python3.6/3.7/3.8/etc won't match this rule)
 
 **Allowing or denying Appimages**

--- a/wiki/Rules.md
+++ b/wiki/Rules.md
@@ -61,10 +61,10 @@ Rules are stored as JSON files inside the `-rule-path` folder, in the simplest c
  - Rule: allow -> port 443 -> Dst IP 1.1.1.1 -> Protocol TCP -> Host www.site.test
    * This rule will match connections to port 443 __AND__ IP 1.1.1.1 __AND__ protocol TCP __AND__ host www.site.test
    * connections to IP 2.2.2.2 won't match, connections to port 80 won't match, etc...
- 
+
  - Rule: allow -> port 53 ->  [x] domains list -> [x] network ranges list
    * This rule will match connections to port 53 __AND__ domains in the list __AND__ IPs in the network ranges list
- - Rule: allow -> port ^(53|80|443)$ -> UID 1000 -> Path /app/bin/test -> [x] domains list 
+ - Rule: allow -> port ^(53|80|443)$ -> UID 1000 -> Path /app/bin/test -> [x] domains list
    * This rule will match connections to ports (53 __OR__ 80 __OR__ 443) __AND__ UID 1000 __AND__ Path /app/bin/test __AND__ domains in the specified.
 
 - If you select multiple lists on the same rule, bear in mind that the connections you want to match must
@@ -72,7 +72,7 @@ Rules are stored as JSON files inside the `-rule-path` folder, in the simplest c
 
 - By default Deny rules take precedence over the rest of the rules. If a connection match a Deny rule, opensnitch won't continue evaluating rules.
 
-- Since v1.2.0, rules are sorted and checked in alphabetical order. You can name them this way to prioritize Deny rules, for example: 
+- Since v1.2.0, rules are sorted and checked in alphabetical order. You can name them this way to prioritize Deny rules, for example:
 ```
 000-allow-chrome-to-specific-domains
 001-allow-not-so-important-rule
@@ -222,13 +222,13 @@ If you want to restrict it further, under the `Addresses` tab you can review wha
   * Allow `systemd-resolved`, `dnsmasq`, `dnscrypt-proxy`, etc, connect only to your DNS nameservers + port 53  + UID.
   * Besides allowing connections to remote DNS servers (9.9.9.9 for example), you may need to allow connections to localhost IPs (127.0.0.1, etc)
   * If you already allowed these stub resolvers, the easiest way would we to delete the existing rule, let it ask you again to allow/deny it, click on the `[+]` button and then select from the pop-up `from this command line` __AND__ to IP x.x.x.x __AND___ to port xxx
-   
+
 
 - Limit what an application can do as much as possible:
   * Filter by executable + command line: You don't want to allow `curl` or `wget` system wide. Instead, allow only a particular command line, for example:
-  
+
     command launched: `$ wget https://mirror.karneval.cz/pub/linux/fedora/linux/releases/34/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-34-1.2.iso`
-    
+
     Instead of allowing `from this executable: wget`, use allow `from this executable` + `from this command line`
 
     You can narrow it further, by allowing `from this command line` + `from this User ID` + `to this IP` + `to this port`
@@ -242,17 +242,17 @@ If you want to restrict it further, under the `Addresses` tab you can review wha
 - Disable unprivileged namespaces to prevent rules bypass
 
   If `/proc/sys/kernel/unprivileged_userns_clone` is set to 1, change it to 0. Until we obtain the checksum of a binary, it's better to set it to 0.
-  
+
 - Don't allow connections opened by binaries located under certain directories: `/dev/shm`, `/tmp`, `/var/tmp`
-  
+
   Why? If someone gets access to your system, usually these directories are the only ones where they can write files, thus it's usually used to drop malicious files, that download remote binaries to escalate privileges, etc.
-  
+
   There're ton of examples (more common on servers than on the desktop):
 
   [Collection of Linux malware payloads](https://github.com/evilsocket/opensnitch/discussions/1119)
-  
+
   https://github.com/timb-machine/linux-malware
-  
+
   ```
   (*) Deny
   [x] From this executable: ^(/tmp/|/var/tmp/|/dev/shm/|/var/run|/var/lock).*

--- a/wiki/SIEM-integration.md
+++ b/wiki/SIEM-integration.md
@@ -52,7 +52,7 @@ Howto configure OpenSnitch with Grafana+Loki+promtail+syslog-ng
 
    The setup is based on the following example, so all the commands to set it up applies:
    https://github.com/grafana/loki/tree/main/examples/getting-started
-   
+
    Docs: https://grafana.com/docs/loki/latest/getting-started/
 
 2. Enter into the directory where the `docker-compose.yaml` is and execute:
@@ -67,7 +67,7 @@ Howto configure OpenSnitch with Grafana+Loki+promtail+syslog-ng
    syslog-ng done
 
    ```
-   
+
 3. Add logger configuration as explained above to send events to 127.0.0.1 on port 514:
 ```json
     "Server": {
@@ -118,14 +118,14 @@ Howto configure OpenSnitch with ElasticSearch + LogStash + Kibana
 1. Enter into the directory where the `docker-compose.yml` is and execute:
    ```bash
    # docker-compose up -d
-   Recreating docker-elk-elasticsearch_logstash_1 ... 
+   Recreating docker-elk-elasticsearch_logstash_1 ...
    Recreating docker-elk-elasticsearch_logstash_1 ... done
-   Recreating docker-elk-syslog_logstash_1 ... 
+   Recreating docker-elk-syslog_logstash_1 ...
    Recreating docker-elk-syslog_logstash_1 ... done
-   Recreating docker-elk-kibana_logstash_1 ... 
+   Recreating docker-elk-kibana_logstash_1 ...
    Recreating docker-elk-kibana_logstash_1 ... done
    ```
-   
+
 2. Add the logger configuration as explained above to send events to 127.0.0.1 on port 3333:
 ```json
     "Server": {
@@ -147,7 +147,7 @@ Howto configure OpenSnitch with ElasticSearch + LogStash + Kibana
 
     If everything went fine, LogStash should be receiving events like this one (`docker logs -f -n 100 <container id>`)
 :
-   
+
    ```
         {
         "@timestamp" => 2023-07-19T13:49:54.546806822Z,
@@ -164,7 +164,7 @@ Howto configure OpenSnitch with ElasticSearch + LogStash + Kibana
         (...)
         }
    ```
-   
+
 7. Open a web browser and head to `127.0.0.1:5601`.
 8. You'll need to create a Data View with a pattern to match a Data Stream, for example: `logs-*`
 
@@ -183,10 +183,10 @@ Howto configure OpenSnitch with ElasticSearch + LogStash + Kibana
 **Notes**
 
  - Configure data retention policy to reduce the size of the DB:
-   
+
    Management -> Data -> Index Lifecycle Policies -> Delete phase
 
- - 
+ -
 
 ### Troubleshooting Elastic stack
 
@@ -194,7 +194,7 @@ Howto configure OpenSnitch with ElasticSearch + LogStash + Kibana
 
    ```bash
    ~ $ ss -lptn | grep -E "(3333|9200)"
-     tcp   LISTEN 0      1024                            [::ffff:127.0.0.1]:3333                   *:*    users:(("java",pid=3712866,fd=107))                                  
+     tcp   LISTEN 0      1024                            [::ffff:127.0.0.1]:3333                   *:*    users:(("java",pid=3712866,fd=107))
      tcp   LISTEN 0      4096                                             *:9200                   *:*    users:(("java",pid=3712294,fd=412))
    ```
 

--- a/wiki/System-rules-legacy.md
+++ b/wiki/System-rules-legacy.md
@@ -102,11 +102,11 @@ Allow nfs connections to mount a remote share:
 ```json
         {
             "Rule": {
-                "Description": "Allow nfs", 
+                "Description": "Allow nfs",
                 "Table": "mangle",
                 "Chain": "OUTPUT",
                 "Parameters": "-p tcp --dport 2049",
-                "Target": "ACCEPT", 
+                "Target": "ACCEPT",
                 "TargetParameters": ""
             }
         }
@@ -155,11 +155,11 @@ table inet filter {
     chain input {
         # block by default incoming connections
         type filter hook input priority filter; policy drop;
-        
+
         # allow already established connections
         ct state { established, related } accept
         ct state invalid drop
-        
+
         # allow ssh
         # tcp dport { 22 } accept
     }

--- a/wiki/System-rules.md
+++ b/wiki/System-rules.md
@@ -101,17 +101,17 @@ Possible options that you can combine to create new chains:
 | Field | Options |
 |-------|---------|
 |Family| ip, ip6, inet, netdev, bridge|
-|Priority| not used|   
+|Priority| not used|
 |Type| filter, mangle, conntrack, natdest, natsource, raw, security, selinux|
 |Hook| prerouting, input, output, postrouting, forward, ingress|
 |Policy| drop, accept|
 
 All the possible options are described here:
 https://wiki.nftables.org/wiki-nftables/index.php/Netfilter_hooks#Priority_within_hook
-    
+
 Rules
 ---
-    
+
 Example:
 ```json
     {
@@ -134,15 +134,15 @@ Example:
  |Expressions| List of options to match against connections: tcp dport 22 (see below)|
  |Target| Action applied on the connection: accept, deny, reject, return, jump, goto, stop, tproxy, redirect, dnat, snat|
  |TargetParameters|Parameters of the given Target. For example: Target -> redirect, TargetParameters -> to :8080|
-    
+
  Rules expressions
  ---
- 
- Expressions are a list of statements that represent the actions to be performed on the connections. They can alter control flow (return, jump to a different chain, accept or drop the packet) or can perform actions, such as logging, rejecting a packet, etc. 
- 
+
+ Expressions are a list of statements that represent the actions to be performed on the connections. They can alter control flow (return, jump to a different chain, accept or drop the packet) or can perform actions, such as logging, rejecting a packet, etc.
+
  https://www.netfilter.org/projects/nftables/manpage.html#lbCV
  https://wiki.nftables.org/wiki-nftables/index.php/Building_rules_through_expressions
- 
+
  Example:
  ```json
                "Expressions": [
@@ -172,9 +172,9 @@ Example:
                 }
               ],
 ```
- 
+
  Each statement has different values (Key and Value field). Not all official statements are supported, only the ones described on the following table:
- 
+
  |Statement Name|Values|Description|Example|
  |---------|------|-----------|-------|
  |log| Key: prefix . TODO: flags, log level|Logs connections to the system with the given prefix|Name: log, Key: prefix, Value: "ssh out"|
@@ -186,12 +186,12 @@ Example:
  |counter| Key: name||Name: counter, Key: name, Value: "dport 22 counter"|
  |ct|Key: state, mark; Value: invalid, new, established, related|Matches connections on the conntrack table||
  |meta|Key: mark|||
- 
+
  The field `Op` is the operator to use on the statement: ==, >=, <=, >, <, != . If it's empty, by default the equal operator (==) will be used.
- 
+
  Examples of supported statements
  ---
- 
+
  log:
  ```json
                    "Statement": {
@@ -205,9 +205,9 @@ Example:
                     ]
                   }
  ```
- 
+
  ---
- 
+
  iifname, oifname:
  ```json
                   "Statement": {
@@ -314,7 +314,7 @@ tcp + dport, multiple ports separated by commas
 
 Rate-limit HTTPS downloads to 1MB/s (table filter, chain input)
 
-https://wiki.nftables.org/wiki-nftables/index.php/Rate_limiting_matchings 
+https://wiki.nftables.org/wiki-nftables/index.php/Rate_limiting_matchings
 
 https://wiki.nftables.org/wiki-nftables/index.php/Quick_reference-nftables_in_10_minutes#Limit
 

--- a/wiki/Why-OpenSnitch-does-not-intercept-application-XXX.md
+++ b/wiki/Why-OpenSnitch-does-not-intercept-application-XXX.md
@@ -5,7 +5,7 @@ if eBPF is not used, and Proc or Audit monitor method are used:
 
 - a process is opening connections too fast (nmap for example, firefox sometimes...). [#343](https://github.com/evilsocket/opensnitch/issues/343#issuecomment-813531496)
 
-- the system has a high load and we're unable to find the process in time. 
+- the system has a high load and we're unable to find the process in time.
 
 - _netlink_ does not return the connection we're querying for, thus we can't search for the PID.
 
@@ -49,7 +49,7 @@ In order to know what process opened a particular connection (in userspace), we 
 
    4.2 Using ProcFS
 
-# 
+#
 ### 1. Intercept the connection using iptables and redirect it to us.
 
 When a new connection is opened, 5 steps happen in the system (well, [many more](https://makelinux.github.io/kernel/map/), but for simplicity sake):
@@ -105,7 +105,7 @@ In this case, it's a UNIX socket, and the connection in this case is a Path to a
 So knowing that we can parse `/proc/net` for connections and inodes, when a new connection is redirected to our process, we can search for it in `/proc/net/` because we know the source port, source IP, destination port and destination IP.
 ```
 $ cat /proc/net/tcp
-  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode                                                     
+  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
    0: 0100007F:13AD 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 18083222 1 ffff9a1677a8cec0 100 0 0 10 0
 ```
 
@@ -163,7 +163,7 @@ However netlink does not always return a match (TODO: explain why), specially fo
 In these cases we can query just for the source port of the connection, which normally will return just one entry, and in some cases (ntp) it will return several inodes for the same srcPort:srcIP<->dstIP:dstPort connection.
 
 
-# 
+#
 ### 3. Find the PID of the connection
 
 
@@ -186,7 +186,7 @@ found: /usr/bin/iceweasel
 easy, right? It is. However, when we reach to this point, the process may have already exited, or the socket being closed. It's not accurate, and besides, many rootkits hide their activity from `/proc` (PIDs, connections, etc).
 
 What options do we have then?
-One approach is to have a list of known PIDs, this is, a list of PIDs which have opened connections. 
+One approach is to have a list of known PIDs, this is, a list of PIDs which have opened connections.
 
 We listen asynchronously for PIDs which open sockets, and when a connection hits the NFQUEUE target and it's redirected to our process, we can get the Inode and search for the PID in a very small list of PIDs. That increase the chances to get the correct PID/process name.
 

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -9,7 +9,7 @@
    1. [Monitor method: audit](monitor-method-auditd)
    2. [Monitor method: eBPF](monitor-method-ebpf)
    3. [Rules](Rules)
-      1. [Best practices](Rules#best-practices) 
+      1. [Best practices](Rules#best-practices)
    5. [Rules editor](Rules-editor)
       1. [Rules examples](Rules-examples)
    6. [System rules](System-rules)

--- a/wiki/block-lists.md
+++ b/wiki/block-lists.md
@@ -62,7 +62,7 @@ How to add a global rule to block ads, trackers or malware domains system-wide o
 Limiting to what domains an application can connect to:
 ---
 
-We'll create 2 rules: 
+We'll create 2 rules:
 - one for allow connections from an app to a limited number of domains.
 - another one for deny everything from that app.
 
@@ -143,7 +143,7 @@ Nets:
 - If you select more than one type of lists on the same rule, bear in mind that the connections you intend to filter must match __ALL__ lists [read more](https://github.com/evilsocket/opensnitch/discussions/877#discussioncomment-5244901).
 - OpenSnitch doesn't refresh periodically the list loaded, but you can do it with this script: [update_adlists.sh](https://raw.githubusercontent.com/evilsocket/opensnitch/master/utils/scripts/ads/update_adlists.sh)
   1. Give it execution permissions:
-  
+
      `chmod +x update_adlists.sh`
   2. Edit the script, and modify the **adsDir** path to point to the directory where you want to save the lists.
   3. Add the script to your user's crontab (in this example, the script will be executed every day at 11am, 17pm and 23pm):
@@ -174,7 +174,7 @@ In order to verify why a domain matched a list, set LogLevel to DEBUG under Pref
 
 (for regexp lists, the last part of the log is the regexp that matched the domain -> ^pixels?[-.])
 
-This feature may not work if your system uses `systemd-resolved` to resolve domains. Compiling `opensnitch-dns.c` [eBPF module](https://github.com/evilsocket/opensnitch/tree/master/ebpf_prog) may help to workaround this problem. 
+This feature may not work if your system uses `systemd-resolved` to resolve domains. Compiling `opensnitch-dns.c` [eBPF module](https://github.com/evilsocket/opensnitch/tree/master/ebpf_prog) may help to workaround this problem.
 
 If blocklists still don't work:
 - allow systemd-resolved to connect **only** to port 53 and 127.0.0.1 + your DNS nameservers.

--- a/wiki/monitor-method-auditd.md
+++ b/wiki/monitor-method-auditd.md
@@ -10,7 +10,7 @@ On Debian/Ubuntu:
 
 * read messages from the pipe to verify that it's working:
   `socat unix-connect:/var/run/audispd_events stdio`
-   
+
   You'll see lot of messages like these ones:
 ```
 mar 08 18:37:48 ono-sendai audit[12704]: SYSCALL arch=c000003e syscall=41 success=yes exit=204 a0=a a1=2 a2=0 a3=7f02480008d0 items=0 ppid=12654 pid=12704 auid=1000 uid=1000 gid=1000 euid=1000 suid>
@@ -23,7 +23,7 @@ mar 08 18:37:48 ono-sendai audit: SOCKADDR saddr=01002FF2756E2F7FF573613030302F3
 **Possible errors:**
 
 * `AuditReader: auditd error%!(EXTRA *net.OpError=read unix @->/var/run/audispd_events: use of closed network connection)`
-  
+
    You need to restart auditd (service auditd restart)
 
 


### PR DESCRIPTION
Also fixed typo for the qttools5-dev package name.
For the clean up used `rg -l0 '[ \t]+$' | xargs -0 sd '[ \t]+$' ''`.
