### PR TITLE
ui: make sure 'service' variable is set

### DIFF
--- a/ui/bin/opensnitch-ui
+++ b/ui/bin/opensnitch-ui
@@ -150,6 +150,8 @@ Examples:
         except Exception:
             pass
 
+    service = None
+
     try:
         Utils.create_socket_dirs()
         app = QtWidgets.QApplication(sys.argv)


### PR DESCRIPTION
Fixes error when running `opensnitch-ui` again:
>     if service:
>        ^^^^^^^
> NameError: name 'service' is not defined. Did you mean: 'UIService'?

Fixes: cdf93c72c172 ("ui: fixed delay closing the GUI")