### PR TITLE
Changed how ebpf build find kernel headers from running to installed version.

### DIFF
--- a/ebpf_prog/Makefile
+++ b/ebpf_prog/Makefile
@@ -3,8 +3,9 @@
 # On Debian based distros we need the following 2 directories.
 # Otherwise, just use the kernel headers from the kernel sources.
 #
-KERNEL_DIR ?= /lib/modules/$(shell uname -r)/source
-KERNEL_HEADERS ?= /usr/src/linux-headers-$(shell uname -r)/
+KERNEL_VER ?= $(shell ls -d /lib/modules/*/source | sort | tail -1 | cut -d/ -f4)
+KERNEL_DIR ?= /lib/modules/$(KERNEL_VER)/source
+KERNEL_HEADERS ?= /usr/src/linux-headers-$(KERNEL_VER)/
 CC = clang
 LLC ?= llc
 ARCH ?= $(shell uname -m)


### PR DESCRIPTION
This get the build working when building in a chroot or when the running kernel is different from the kernel headers installed.