### PR TITLE
refactor: Update localhost rules and add IPv6

### DIFF
--- a/daemon/data/rules/000-allow-localhost6.json
+++ b/daemon/data/rules/000-allow-localhost6.json
@@ -1,13 +1,13 @@
 {
-  "created": "2025-04-09T23:21:35-06:00",
-  "updated": "2025-04-09T23:21:35-06:00",
-  "name": "000-allow-localhost",
+  "created": "2025-04-09T23:17:39-06:00",
+  "updated": "2025-04-09T23:17:39-06:00",
+  "name": "000-allow-localhost6",
   "description": "Allow connections to localhost. See this link for more information:\nhttps://github.com/evilsocket/opensnitch/wiki/Rules#localhost-connections",
   "action": "allow",
   "duration": "always",
   "operator": {
     "operand": "dest.network",
-    "data": "127.0.0.0/8",
+    "data": "::1/128",
     "type": "network",
     "list": [],
     "sensitive": false


### PR DESCRIPTION
- Changed the local host rule from using regexp to network operator
- Updated destination IP check from specific addresses to CIDR notation (127.0.0.0/8)
- Added new rule for IPv6 localhost connections (::1/128)
- Added nolog property to prevent logging of localhost traffic