### PR TITLE
Added ebpf build rule mapping for loongarch64 to loongarch.

### DIFF
--- a/ebpf_prog/Makefile
+++ b/ebpf_prog/Makefile
@@ -22,6 +22,8 @@ else ifeq ($(ARCH),armv8l)
 	ARCH := arm
 else ifeq ($(ARCH),aarch64)
 	ARCH := arm64
+else ifeq ($(ARCH),loongarch64)
+	ARCH := loongarch
 else ifeq ($(ARCH),s390x)
 	ARCH := s390
 endif


### PR DESCRIPTION
This ensure the kernel headers are found during compilation.