### PR TITLE
Add loongarch64 support

### DIFF
--- a/ebpf_prog/bpf_headers/bpf_tracing.h
+++ b/ebpf_prog/bpf_headers/bpf_tracing.h
@@ -17,6 +17,9 @@
 #elif defined(__TARGET_ARCH_arm64)
 	#define bpf_target_arm64
 	#define bpf_target_defined
+#elif defined(__TARGET_ARCH_loongarch)
+	#define bpf_target_loongarch
+	#define bpf_target_defined
 #elif defined(__TARGET_ARCH_mips)
 	#define bpf_target_mips
 	#define bpf_target_defined
@@ -46,6 +49,9 @@
 	#define bpf_target_defined
 #elif defined(__aarch64__)
 	#define bpf_target_arm64
+	#define bpf_target_defined
+#elif defined(__loongarch64)
+	#define bpf_target_loongarch
 	#define bpf_target_defined
 #elif defined(__mips__)
 	#define bpf_target_mips
@@ -178,6 +184,20 @@ struct pt_regs___arm64 {
 #define __PT_IP_REG pc
 #define PT_REGS_PARM1_SYSCALL(x) PT_REGS_PARM1_CORE_SYSCALL(x)
 #define PT_REGS_PARM1_CORE_SYSCALL(x) BPF_CORE_READ((const struct pt_regs___arm64 *)(x), orig_x0)
+
+#elif defined(bpf_target_loongarch)
+
+#define __PT_REGS_CAST(x) ((const struct user_pt_regs *)(x))
+#define __PT_PARM1_REG regs[4]
+#define __PT_PARM2_REG regs[5]
+#define __PT_PARM3_REG regs[6]
+#define __PT_PARM4_REG regs[7]
+#define __PT_PARM5_REG regs[8]
+#define __PT_RET_REG regs[1]
+#define __PT_FP_REG regs[22]
+#define __PT_RC_REG regs[4]
+#define __PT_SP_REG regs[3]
+#define __PT_IP_REG pc
 
 #elif defined(bpf_target_mips)
 


### PR DESCRIPTION
Dear maintainers,

Compiling the opensnitch failed for loong64 in the Debian Package Auto-Building environment.
Details can be found at https://buildd.debian.org/status/fetch.php?pkg=opensnitch&arch=loong64&ver=1.6.8-11&stamp=1745911996&raw=0.

Applied patch from https://github.com/evilsocket/opensnitch/blob/master/ebpf_prog/Makefile#L25, the compilation continues with the following new error,
```
opensnitch.c:138:38: error: Must specify a BPF target arch via __TARGET_ARCH_xxx
  138 |     struct sock *sk = (struct sock *)PT_REGS_PARM1(ctx);
      |                                      ^
./bpf_headers/bpf_tracing.h:335:29: note: expanded from macro 'PT_REGS_PARM1'
  335 | #define PT_REGS_PARM1(x) ({ _Pragma(__BPF_TARGET_MISSING); 0l; })
      |                             ^
<scratch space>:93:6: note: expanded from here
   93 |  GCC error "Must specify a BPF target arch via __TARGET_ARCH_xxx"
      |      ^
......
```

Based on this commit, I have built opensnitch successfully on locally.
```
   dh_builddeb -O--builddirectory=_build -O--buildsystem=golang
	dpkg-deb --root-owner-group --build debian/opensnitch ..
	dpkg-deb --root-owner-group --build debian/.debhelper/opensnitch/dbgsym-root ..
	dpkg-deb --root-owner-group --build debian/python3-opensnitch-ui ..
	dpkg-deb --root-owner-group --build debian/opensnitch-ebpf-modules ..
dpkg-deb: building package 'opensnitch-dbgsym' in '../opensnitch-dbgsym_1.6.8-11+loong64_loong64.deb'.
dpkg-deb: building package 'opensnitch' in '../opensnitch_1.6.8-11+loong64_loong64.deb'.
dpkg-deb: building package 'python3-opensnitch-ui' in '../python3-opensnitch-ui_1.6.8-11+loong64_all.deb'.
dpkg-deb: building package 'opensnitch-ebpf-modules' in '../opensnitch-ebpf-modules_1.6.8-11+loong64_loong64.deb'.
 dpkg-genbuildinfo -O../opensnitch_1.6.8-11+loong64_loong64.buildinfo
 dpkg-genchanges -O../opensnitch_1.6.8-11+loong64_loong64.changes
```

Please review.