### PR TITLE
ui: remove unused imports

### DIFF
--- a/ui/bin/opensnitch-ui
+++ b/ui/bin/opensnitch-ui
@@ -40,7 +40,7 @@ if dist_path not in sys.path:
 
 from opensnitch.service import UIService
 from opensnitch.config import Config
-from opensnitch.utils import Themes, Utils, Versions, Message
+from opensnitch.utils import Themes, Utils, Versions
 from opensnitch.utils.xdg import xdg_opensnitch_dir, xdg_current_session
 from opensnitch import auth
 

--- a/ui/opensnitch/customwidgets/firewalltableview.py
+++ b/ui/opensnitch/customwidgets/firewalltableview.py
@@ -2,7 +2,7 @@
 from PyQt5 import QtCore
 from PyQt5.QtGui import QStandardItemModel, QStandardItem
 from PyQt5.QtSql import QSqlQuery, QSqlError
-from PyQt5.QtWidgets import QTableView, QAbstractSlider, QItemDelegate, QAbstractItemView, QPushButton, QWidget, QVBoxLayout
+from PyQt5.QtWidgets import QTableView
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtCore import QCoreApplication as QC
 

--- a/ui/opensnitch/customwidgets/updownbtndelegate.py
+++ b/ui/opensnitch/customwidgets/updownbtndelegate.py
@@ -1,6 +1,6 @@
-from PyQt5 import Qt, QtCore
+from PyQt5 import QtCore
 from PyQt5.QtGui import QRegion
-from PyQt5.QtWidgets import QItemDelegate, QAbstractItemView, QPushButton, QWidget, QVBoxLayout, QSizePolicy
+from PyQt5.QtWidgets import QItemDelegate, QAbstractItemView, QPushButton, QWidget, QVBoxLayout
 from PyQt5.QtCore import pyqtSignal
 
 class UpDownButtonDelegate(QItemDelegate):

--- a/ui/opensnitch/dialogs/firewall_rule.py
+++ b/ui/opensnitch/dialogs/firewall_rule.py
@@ -3,12 +3,12 @@ import os
 import os.path
 import ipaddress
 
-from PyQt5 import QtCore, QtGui, uic, QtWidgets
+from PyQt5 import QtCore, uic, QtWidgets
 from PyQt5.QtCore import QCoreApplication as QC
 
 from opensnitch.config import Config
 from opensnitch.nodes import Nodes
-from opensnitch.utils import NetworkServices, NetworkInterfaces, QuickHelp, Icons, Utils
+from opensnitch.utils import NetworkServices, NetworkInterfaces, QuickHelp, Icons
 import opensnitch.firewall as Fw
 from opensnitch.firewall.utils import Utils as FwUtils
 

--- a/ui/opensnitch/firewall/__init__.py
+++ b/ui/opensnitch/firewall/__init__.py
@@ -8,7 +8,6 @@ from opensnitch.nodes import Nodes
 from .enums import *
 from .rules import *
 from .chains import *
-from .utils import Utils
 from .exprs import *
 from .profiles import *
 

--- a/ui/opensnitch/nodes.py
+++ b/ui/opensnitch/nodes.py
@@ -1,4 +1,4 @@
-from PyQt5.QtCore import QObject, pyqtSignal, pyqtSlot
+from PyQt5.QtCore import QObject, pyqtSignal
 from queue import Queue
 from datetime import datetime
 import time

--- a/ui/opensnitch/notifications.py
+++ b/ui/opensnitch/notifications.py
@@ -1,6 +1,4 @@
 from PyQt5.QtCore import QCoreApplication as QC
-import os
-from opensnitch.utils import Utils
 from opensnitch.config import Config
 
 class DesktopNotifications():


### PR DESCRIPTION
> [!WARNING]  
> I didn't actually test the changes, so a test/review would be very much appreciated and required before a potential merge.

My LSP showed some unused imports in the ui source.
For each of the files changed, I searched the corresponding file for the appearance of the seemingly unused import. If it didn't occur anywhere except in the import statement, I removed it.

There were some more occurences where imports currently seem unused but their usage is just commented out at the moment, I didn't remove such.