### PR TITLE
check whether dist_path exists

### DIFF
--- a/ui/bin/opensnitch-ui
+++ b/ui/bin/opensnitch-ui
@@ -35,7 +35,7 @@ from concurrent import futures
 import grpc
 
 dist_path = '/usr/lib/python3/dist-packages/'
-if dist_path not in sys.path:
+if os.path.exists(dist_path) and dist_path not in sys.path:
     sys.path.append(dist_path)
 
 from opensnitch.service import UIService


### PR DESCRIPTION
"dist_path" seems to be a debian thing, in openSUSE for example the path does not exist.