### PR TITLE
Fix: Improve AppImage rule matching by generalizing dynamic mount path

### DIFF
--- a/ui/opensnitch/dialogs/ruleseditor.py
+++ b/ui/opensnitch/dialogs/ruleseditor.py
@@ -470,6 +470,10 @@ class RulesEditorDialog(QtWidgets.QDialog, uic.loadUiType(DIALOG_UI_PATH)[0]):
         self.md5Line.setEnabled(False)
 
     def _load_rule(self, addr=None, rule=None):
+        # Generalize AppImage path if rule is for a mounted AppImage
+        if hasattr(rule, "path") and isinstance(rule.path, str) and rule.path.startswith("/tmp/.mount_"):
+            rule.path = "/tmp/.mount_[A-Za-z0-9]+"
+
         if self._load_nodes(addr) == False:
             return False
 


### PR DESCRIPTION
AppImages often mount to dynamic paths like:

`/tmp/.mount_<random>`

Due to the randomness of these folder names, OpenSnitch was failing to match rules for AppImages unless the mount name remained identical — which it rarely does.

This fix modifies the `_load_rule()` method in the `RulesEditorDialog` to detect AppImage paths starting with `/tmp/.mount_` and replaces them with a generalized regex pattern:

`/tmp/.mount_[A-Za-z0-9]+`

This allows consistent rule matching for AppImages regardless of the specific mount folder name on each launch.

Fixes: #1377
