### PR TITLE
Update generate_i18n.sh - find lrelease

### DIFF
--- a/ui/i18n/generate_i18n.sh
+++ b/ui/i18n/generate_i18n.sh
@@ -2,16 +2,24 @@
 
 app_name="opensnitch"
 langs_dir="./locales"
-lrelease="lrelease"
-if ! command -v lrelease >/dev/null; then
-    # on fedora
-    lrelease="lrelease-qt5"
+lrelease_bin=""
+for lbin in $LRELEASE lrelease lrelease6 lrelease-qt6
+do
+    lrelease_bin="$(command -v $lbin)"
+    if [ -n "$lrelease_bin" ]; then
+        break
+    fi
+done
+if [ -z "$lrelease_bin" ]; then
+    echo "lrelease binary not found!"
+    exit 1
 fi
+echo "using $lrelease_bin"
 
 #pylupdate5 opensnitch_i18n.pro
 
 for lang in $(ls $langs_dir)
 do
     lang_path="$langs_dir/$lang/$app_name-$lang"
-    $lrelease $lang_path.ts -qm $lang_path.qm
+    $lrelease_bin $lang_path.ts -qm $lang_path.qm
 done


### PR DESCRIPTION
This should simplify the search for the `lrelease` binary:
`lrelease` - Debian/Ubuntu (?)
`lrelease6` - openSUSE
`lrelease-qt6` - Fedora

In addition, you can specify the path to an `lrelease` binary with `LRELEASE`, e.g.:
`export LRELEASE="/usr/local/bin/my-lrelease-v6"`
