### PR TITLE
ui: switch to python-slugify

### DIFF
--- a/ui/requirements.txt
+++ b/ui/requirements.txt
@@ -2,7 +2,7 @@
 pyqt6>=6.4
 protobuf
 grpcio-tools>=1.10.1
-unicode_slugify==0.1.5
+python-slugify>=7.0.0
 
 # suggested
 #  file changes monitoring


### PR DESCRIPTION
unicode-slugify is basically abandoned upstream. Its repository [1] has seen the last actual code change in 2018. It uses the deprecated `nose` testing framework.

In nixpkgs, we patched it to use pytest, but made some mistakes in those patches, resulting in no tests actually executing. I actually fixed the tests to run, but most of the tests fail: unicode does not reliably get replaced with a slugified version.

There does exist an actual need for slugification. However, the used slugify package should actually work and be reasonably maintained. The replacement proposed here is `python-slugify` [2], which sees active development in its repository while the used API (both import name and the basic function signature `slugify(str)`) is identical.

The version requirement of >=7.0.0 is from their official support matrix for py >= 3.7, though i did my testing with python-slugify 8.0.4.

[1] https://github.com/mozilla/unicode-slugify
[2] https://pypi.org/project/python-slugify/