### PR TITLE
Fix build error with grpc_tools.protoc by enabling experimental_editions

### DIFF
--- a/proto/Makefile
+++ b/proto/Makefile
@@ -4,7 +4,7 @@ all: ../daemon/ui/protocol/ui.pb.go ../ui/opensnitch/ui_pb2.py
 	protoc -I. ui.proto --go_out=../daemon/ui/protocol/ --go-grpc_out=../daemon/ui/protocol/ --go_opt=paths=source_relative --go-grpc_opt=paths=source_relative
 
 ../ui/opensnitch/ui_pb2.py: ui.proto
-	python3 -m grpc_tools.protoc -I. --python_out=../ui/opensnitch/proto/ --grpc_python_out=../ui/opensnitch/proto/ ui.proto
+	python3 -m grpc_tools.protoc --experimental_editions -I. --python_out=../ui/opensnitch/proto/ --grpc_python_out=../ui/opensnitch/proto/ ui.proto
 
 clean:
 	@rm -rf ../daemon/ui/protocol/ui.pb.go


### PR DESCRIPTION
Fix build error with grpc_tools.protoc by enabling experimental_editions

Seen on ArchLinux

```
protoc -I. ui.proto --go_out=../daemon/ui/protocol/ --go-grpc_out=../daemon/ui/protocol/ --go_opt=paths=source_relative --go-grpc_opt=paths=source_relative
python3 -m grpc_tools.protoc -I. --python_out=../ui/opensnitch/proto/ --grpc_python_out=../ui/opensnitch/proto/ ui.proto
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
E0000 00:00:1757449340.684078   51069 command_line_interface.cc:1557] Built-in generator --grpc_python_out specifies a maximum edition 2023 which is not the protoc maximum 2024.
make: *** [Makefile:7: ../ui/opensnitch/ui_pb2.py] Error 1
```
More info https://github.com/evilsocket/opensnitch/issues/1429
