### PR TITLE
fix: restore maximized window state correctly when loading dialog geometry

### DIFF
--- a/ui/opensnitch/dialogs/stats.py
+++ b/ui/opensnitch/dialogs/stats.py
@@ -849,8 +849,8 @@ class StatsDialog(QtWidgets.QDialog, uic.loadUiType(DIALOG_UI_PATH)[0]):
                     # docs: https://doc.qt.io/qt-5/qwidget.html#setWindowState
                     self.setWindowState(self.windowState() & ~QtCore.Qt.WindowState.WindowMinimized | QtCore.Qt.WindowState.WindowActive)
 
-    def showEvent(self, event):
-        super(StatsDialog, self).showEvent(event)
+    def show(self):
+        super(StatsDialog, self).show()
         self._shown_trigger.emit()
         window_title = QC.translate("stats", "OpenSnitch Network Statistics {0}").format(version)
         if self._address is not None:


### PR DESCRIPTION
This change fixes an issue where the statistics dialog would not properly restore its maximized state when reopening. The previous implementation attempted to manually set the window geometry to simulate a maximized state, but this approach was unreliable and didn't properly handle screen boundaries or multi-monitor setups.

The fix replaces the manual geometry setting with a proper call to showMaximized() when the dialog is visible, ensuring that Qt's window management correctly handles the maximized state restoration. This provides consistent behavior across different platforms and display configurations.

Changes made:
- Removed the manual geometry calculation that attempted to simulate maximized state
- Added proper isVisible() check before calling showMaximized() to ensure the window is properly initialized
- Simplified the maximized state restoration logic to use Qt's built-in functionality

A potential caveat is that [showMaximized()](https://doc.qt.io/qt-6/qwidget.html#showMaximized) may [encounter problems with X11](https://doc.qt.io/qt-6/application-windows.html#x11-peculiarities) although the benefit may outweigh the risk to enhance multi-monitor capability and better compensate for desktop resolution changes. More testing is warranted. Patched 1.7.2 seems to work as expected with **KDE Plasma 6.5.2 with Wayland**, **Linux Mint 22.2 Cinnamon 6.4.8**, **Ubuntu 24.04 with Gnome 46** and **Ubuntu 25.04 with Gnome 48**.

_X11 provides no standard or easy way to get the frame geometry once the window is decorated. Qt solves this problem with nifty heuristics and clever code that works on a wide range of window managers that exist today. Don't be surprised if you find one where [QWidget::frameGeometry](https://doc.qt.io/qt-6/qwidget.html#frameGeometry-prop)() returns wrong results though._

_Nor does X11 provide a way to maximize a window. [QWidget::showMaximized](https://doc.qt.io/qt-6/qwidget.html#showMaximized)() has to emulate the feature. Its result depends on the result of [QWidget::frameGeometry](https://doc.qt.io/qt-6/qwidget.html#frameGeometry-prop)() and the capability of the window manager to do proper window placement, neither of which can be guaranteed._