### PR TITLE
fix(ui): use user-specific socket path to support multiple users (#1341)

### DIFF
--- a/ui/bin/opensnitch-ui
+++ b/ui/bin/opensnitch-ui
@@ -95,6 +95,30 @@ def restrict_socket_perms(socket):
     except Exception as e:
         print("Unable to change unix socket permissions:", socket, e)
 
+def get_default_socket_path():
+    """Get the default socket path for this user.
+
+    Returns a user-specific socket path to allow multiple users to run
+    separate UI instances (issue #1341). Falls back to /tmp if the
+    user-specific runtime directory is not available.
+    """
+    uid = os.getuid()
+    # Prefer XDG_RUNTIME_DIR which is /run/user/{UID} on most systems
+    xdg_runtime = os.environ.get('XDG_RUNTIME_DIR')
+    if xdg_runtime and os.path.isdir(xdg_runtime):
+        socket_dir = os.path.join(xdg_runtime, 'opensnitch')
+        if os.path.isdir(socket_dir):
+            return f"unix://{socket_dir}/osui.sock"
+
+    # Try standard paths
+    for base in [f"/run/user/{uid}", f"/var/run/user/{uid}"]:
+        socket_dir = os.path.join(base, 'opensnitch')
+        if os.path.isdir(socket_dir):
+            return f"unix://{socket_dir}/osui.sock"
+
+    # Fall back to /tmp (global, only one user can use it)
+    return "unix:///tmp/osui.sock"
+
 def configure_screen_scale_factor(cfg):
     """configure qt screen scale:
         https://doc.qt.io/qt-5/highdpi.html#high-dpi-support-in-qt
@@ -142,12 +166,14 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='OpenSnitch UI service.', formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("--socket", dest="socket", help='''
 Path of the unix socket for the gRPC service (https://github.com/grpc/grpc/blob/master/doc/naming.md).
-Default: unix:///tmp/osui.sock
+Default: unix://$XDG_RUNTIME_DIR/opensnitch/osui.sock (user-specific)
+         Falls back to unix:///tmp/osui.sock if runtime dir unavailable.
 
 Examples:
     - Listening on Unix socket: opensnitch-ui --socket unix:///tmp/osui.sock
-        * Use unix:///run/1000/YOUR_USER/opensnitch/osui.sock for better privacy.
     - Listening on port 50051, all interfaces: opensnitch-ui --socket "[::]:50051"
+
+Note: The daemon must be configured to connect to the same socket path.
                         ''', metavar="FILE")
     parser.add_argument("--socket-auth", dest="socket_auth", help="Auth type: simple, tls-simple, tls-mutual")
     parser.add_argument("--tls-ca-cert", dest="tls_ca_cert", help="path to the CA cert")
@@ -214,14 +240,14 @@ Examples:
         thm.load_theme(app)
 
         if args.socket is None:
-            # default
-            args.socket = "unix:///tmp/osui.sock"
+            # default: use user-specific path to support multiple users (#1341)
+            args.socket = get_default_socket_path()
 
             addr = cfg.getSettings(Config.DEFAULT_SERVER_ADDR)
             if addr is not None and addr != "":
                 if addr.startswith("unix://"):
                     if not os.path.exists(os.path.dirname(addr[7:])):
-                        log.warning("WARNING: unix socket path does not exist, using unix:///tmp/osui.sock, %s", addr)
+                        log.warning("WARNING: unix socket path does not exist, using %s, %s", args.socket, addr)
                     else:
                         args.socket = addr
                 else:


### PR DESCRIPTION
## Summary

Fixes #1341 - OpenSnitch GUI can be used only by one user at a time

The UI was using a hardcoded global socket path `/tmp/osui.sock`, which prevented multiple users from running the UI simultaneously. When user 1 binds to this socket, user 2 gets "address already in use" error.

### Changes

Added `get_default_socket_path()` function that returns a user-specific socket path:

1. First tries `$XDG_RUNTIME_DIR/opensnitch/osui.sock` (preferred)
2. Falls back to `/run/user/{UID}/opensnitch/osui.sock`
3. Falls back to `/var/run/user/{UID}/opensnitch/osui.sock`
4. Final fallback to `/tmp/osui.sock` for compatibility

This allows each user to have their own socket in their runtime directory, preventing conflicts.

### Limitations

This is a **partial fix** that addresses the immediate issue of the UI failing to start. For full multi-user support where ALL logged-in users receive connection prompts:

- The daemon currently connects to only ONE UI socket (configured in `/etc/opensnitchd/default-config.json`)
- Full multi-user support would require architectural changes to allow the daemon to connect to multiple UI instances

### Workaround for Multi-User Prompts

Users who need prompts to work for a specific user can update the daemon config to point to that user's socket:
```json
{
    "Server": {
        "Address": "unix:///run/user/1000/opensnitch/osui.sock"
    }
}
```

## Test Plan

- [ ] Start UI as user 1 on tty1
- [ ] Switch to tty2, log in as user 2
- [ ] Start UI as user 2 - should now succeed without "address already in use" error
- [ ] Verify each UI uses its own socket path in `/run/user/{UID}/opensnitch/`
- [ ] Verify fallback to `/tmp/osui.sock` when runtime dir is unavailable

## Reviewers

@Damglador - Original reporter