### PR TITLE
feat(rules): add priority field and configurable evaluation mode (#1460)

### DIFF
--- a/daemon/data/default-config.json
+++ b/daemon/data/default-config.json
@@ -30,7 +30,8 @@
     },
     "Rules": {
         "Path": "/etc/opensnitchd/rules/",
-        "EnableChecksums": false
+        "EnableChecksums": false,
+        "EvaluationMode": "deny-priority"
     },
     "Ebpf": {
         "EventsWorkers": 8,

--- a/daemon/rule/rule.go
+++ b/daemon/rule/rule.go
@@ -34,6 +34,16 @@ const (
 	Always  = Duration("always")
 )
 
+// EvaluationMode determines how rules are evaluated when multiple match
+type EvaluationMode string
+
+const (
+	// EvalDenyPriority is the default mode: deny/reject rules always win over allow
+	EvalDenyPriority = EvaluationMode("deny-priority")
+	// EvalFirstMatch uses RouterOS-style evaluation: first matching rule wins
+	EvalFirstMatch = EvaluationMode("first-match")
+)
+
 // Rule represents an action on a connection.
 // The fields match the ones saved as json to disk.
 // If a .json rule file is modified on disk, it's reloaded automatically.
@@ -50,6 +60,10 @@ type Rule struct {
 	Enabled     bool     `json:"enabled"`
 	Precedence  bool     `json:"precedence"`
 	Nolog       bool     `json:"nolog"`
+	// Priority determines rule evaluation order (lower = higher priority).
+	// Rules with equal priority are sorted alphabetically by name.
+	// Default is 0. Use negative values for higher priority rules.
+	Priority int `json:"priority"`
 }
 
 // Create creates a new rule object with the specified parameters.

--- a/daemon/ui/config/config.go
+++ b/daemon/ui/config/config.go
@@ -52,6 +52,10 @@ type (
 	RulesOptions struct {
 		Path            string `json:"Path"`
 		EnableChecksums bool   `json:"EnableChecksums"`
+		// EvaluationMode determines how rules are matched:
+		// - "deny-priority" (default): deny/reject rules always win over allow
+		// - "first-match": first matching rule wins (RouterOS-style)
+		EvaluationMode string `json:"EvaluationMode"`
 	}
 
 	// FwOptions struct

--- a/daemon/ui/config_utils.go
+++ b/daemon/ui/config_utils.go
@@ -196,6 +196,7 @@ func (c *Client) reloadConfiguration(reload bool, newConfig *config.Config) (err
 
 	// 1. load rules
 	c.rules.EnableChecksums(newConfig.Rules.EnableChecksums)
+	c.rules.SetEvaluationMode(newConfig.Rules.EvaluationMode)
 	if newConfig.Rules.Path == "" || c.config.Rules.Path != newConfig.Rules.Path {
 		c.rules.Reload(newConfig.Rules.Path)
 		log.Debug("[config] reloading config.rules.path, old: <%s> new: <%s>", c.config.Rules.Path, newConfig.Rules.Path)


### PR DESCRIPTION
## Summary

Implements #1460 - Improve rule ordering logic

This PR adds explicit rule ordering and configurable evaluation modes, addressing the feature request for more intuitive rule management.

### New Features

#### 1. Priority Field for Rules

Rules now have an explicit `priority` field (integer, default 0):
- Lower values = higher priority
- Rules are sorted by priority first, then alphabetically by name
- Replaces the implicit file naming convention (000-, 001-) with explicit control

Example rule:
```json
{
    "name": "block-malware-domains",
    "priority": -100,
    "action": "deny",
    "operator": { ... }
}
```

#### 2. Configurable Evaluation Modes

New config option `Rules.EvaluationMode`:

| Mode | Description |
|------|-------------|
| `deny-priority` | **Default.** Current behavior - deny/reject rules always win over allow rules |
| `first-match` | RouterOS-style - first matching rule wins, giving full control via priority |

Example config:
```json
"Rules": {
    "Path": "/etc/opensnitchd/rules/",
    "EnableChecksums": false,
    "EvaluationMode": "first-match"
}
```

### How It Works

**deny-priority mode (default):**
1. Rules evaluated in priority order
2. If a matching Allow rule is found, save it but keep looking
3. If a matching Deny/Reject or Precedence rule is found, return immediately
4. Return the last saved match

**first-match mode:**
1. Rules evaluated in priority order
2. First matching rule wins immediately
3. No special handling for Deny vs Allow

### Backwards Compatibility

- Default evaluation mode is `deny-priority` (current behavior)
- Default priority is 0, so existing rules work unchanged
- Existing file naming conventions (000-, 001-) still provide ordering for rules with same priority

### Files Changed

- `daemon/rule/rule.go` - Added Priority field and EvaluationMode type
- `daemon/rule/loader.go` - Updated sorting and matching logic
- `daemon/ui/config/config.go` - Added EvaluationMode to config struct
- `daemon/ui/config_utils.go` - Apply evaluation mode from config
- `daemon/data/default-config.json` - Added EvaluationMode default

## Test Plan

- [ ] Create rules with different priorities, verify they're evaluated in correct order
- [ ] Test `deny-priority` mode: confirm deny rules still win over allow
- [ ] Test `first-match` mode: confirm first matching rule wins regardless of action
- [ ] Verify existing rules without priority field work (default to 0)
- [ ] Verify config reload applies new evaluation mode

## Reviewers

@savchenko - Original requester
@Danny3 - Commented on the feature request