### PR TITLE
fix(ui): use temporary duration when popup times out (#1385)

### DIFF
--- a/ui/opensnitch/dialogs/prompt/dialog.py
+++ b/ui/opensnitch/dialogs/prompt/dialog.py
@@ -585,7 +585,13 @@ class PromptDialog(QtWidgets.QDialog, uic.loadUiType(DIALOG_UI_PATH)[0]):
             self._rule = ui_pb2.Rule(name="user.choice")
             self._rule.created = int(datetime.now().timestamp())
             self._rule.enabled = True
-            self._rule.duration = utils.get_duration(self.durationCombo.currentIndex())
+            # If the popup timed out without user interaction, always use "once" duration
+            # to avoid creating permanent rules when the user is away (#1385).
+            # Only explicit user confirmation should create permanent rules.
+            if self._timeout_triggered:
+                self._rule.duration = Config.DURATION_ONCE
+            else:
+                self._rule.duration = utils.get_duration(self.durationCombo.currentIndex())
 
             self._rule.action = Config.ACTION_ALLOW
             if self._default_action == Config.ACTION_DENY_IDX:


### PR DESCRIPTION
## Summary

Fixes #1385 - Expiring advanced view pop-up will create blanket deny rule for application if "Destination IP" is not checked

### The Problem

When a popup expires (times out) without user interaction, it currently applies all the configured default settings, including the duration. If the user has "forever" as the default duration, this creates **permanent blanket deny rules** when the user is away from the machine.

This is dangerous behavior for a security application - a user who steps away shouldn't return to find their applications permanently blocked.

### The Fix

When `_timeout_triggered` is True, the duration is now forced to `"once"` instead of using the configured default:

```python
if self._timeout_triggered:
    self._rule.duration = Config.DURATION_ONCE
else:
    self._rule.duration = utils.get_duration(self.durationCombo.currentIndex())
```

### Behavior Change

| Scenario | Before | After |
|----------|--------|-------|
| User clicks Allow/Deny | Uses selected duration | Uses selected duration (unchanged) |
| Popup times out | Uses default duration (could be "forever") | Forces "once" duration |

### Rationale

- **Explicit confirmation = full control**: When the user actively clicks, they're confirming their choice including the duration
- **Timeout = conservative default**: When the popup expires unattended, the system shouldn't make permanent decisions
- **Desktop notifications still inform**: The user will see a notification about the temporary rule and can review/make permanent in the Rules tab

## Test Plan

- [ ] Set default duration to "forever" and default action to "deny"
- [ ] Trigger a popup for a new connection
- [ ] Let the popup expire without clicking
- [ ] Verify the created rule has duration "once" (not "forever")
- [ ] Verify actively clicking Deny creates a "forever" rule
- [ ] Verify notification is still shown for the timeout rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)