### PR TITLE
ui: inform about failure to connect to socket

### DIFF
--- a/ui/bin/opensnitch-ui
+++ b/ui/bin/opensnitch-ui
@@ -291,24 +291,36 @@ Examples:
             args.socket = "unix-abstract:{0}".format(parts[1])
 
         log.info("[server] using address: %s auth type: %s keepalive: %d keepalive timeout: %d", args.socket, auth_type, keepalive, keepalive_timeout)
+        try:
+          if auth_type == auth.Simple or auth_type == "":
+              server.add_insecure_port(args.socket)
+          else:
+              auth_ca_cert = args.tls_ca_cert
+              auth_cert = args.tls_cert
+              auth_certkey = args.tls_key
+              if auth_cert == None:
+                  auth_cert = cfg.getSettings(Config.AUTH_CERT)
+              if auth_certkey == None:
+                  auth_certkey = cfg.getSettings(Config.AUTH_CERTKEY)
+              if auth_ca_cert == None:
+                  auth_ca_cert = cfg.getSettings(Config.AUTH_CA_CERT)
 
-        if auth_type == auth.Simple or auth_type == "":
-            server.add_insecure_port(args.socket)
-        else:
-            auth_ca_cert = args.tls_ca_cert
-            auth_cert = args.tls_cert
-            auth_certkey = args.tls_key
-            if auth_cert == None:
-                auth_cert = cfg.getSettings(Config.AUTH_CERT)
-            if auth_certkey == None:
-                auth_certkey = cfg.getSettings(Config.AUTH_CERTKEY)
-            if auth_ca_cert == None:
-                auth_ca_cert = cfg.getSettings(Config.AUTH_CA_CERT)
+              tls_creds = auth.get_tls_credentials(auth_ca_cert, auth_cert, auth_certkey)
+              if tls_creds == None:
+                  raise Exception("Invalid TLS credentials. Review the server key and cert files.")
+              server.add_secure_port(args.socket, tls_creds)
+        except Exception as e:
+            msg = QtWidgets.QMessageBox()
+            msg.setIcon(QtWidgets.QMessageBox.Critical)
+            msg.setText(
+f"""Failed to connect to socket.
+Other user might be running OpenSnitch UI.
+Running multiple instances of OpenSnitch UI on one system is currently unsupported.
 
-            tls_creds = auth.get_tls_credentials(auth_ca_cert, auth_cert, auth_certkey)
-            if tls_creds == None:
-                raise Exception("Invalid TLS credentials. Review the server key and cert files.")
-            server.add_secure_port(args.socket, tls_creds)
+Exception: {e}"""
+            )
+            msg.exec()
+            on_exit()
 
         # https://stackoverflow.com/questions/5160577/ctrl-c-doesnt-work-with-pyqt
         signal.signal(signal.SIGINT, signal.SIG_DFL)


### PR DESCRIPTION
Not quite a fix for https://github.com/evilsocket/opensnitch/issues/1341, but at least it makes it clear for the user that the issue is in another opensnitch-ui instance and is not some random bug.

Instead of silently crashing, opensnitch-ui will pup-up the dialog shown on the screenshot and only then exit:
<img width="1137" height="586" alt="Знімок_20260104_170731" src="https://github.com/user-attachments/assets/8e6393e7-4323-4072-b1cf-425e512ce2f8" />
