### PR TITLE
Match by full command by default for high-risk executables

### DIFF
--- a/ui/opensnitch/config.py
+++ b/ui/opensnitch/config.py
@@ -111,6 +111,7 @@ class Config:
     DEFAULT_POPUP_ADVANCED_CHECKSUM = "global/default_popup_advanced_checksum"
     DEFAULT_FW_INTERCEPTION_ENABLED = "global/interception_enabled"
     DEFAULT_PERSIST_INTERCEPTION_STATE = "global/persist_interception_state"
+    DEFAULT_POPUP_ADVANCED_FULL_COMMAND = "global/default_popup_advanced_full_command"
     DEFAULT_SERVER_ADDR  = "global/server_address"
     DEFAULT_SERVER_MAX_MESSAGE_LENGTH  = "global/server_max_message_length"
     DEFAULT_SERVER_MAX_WORKERS = "global/max_workers"

--- a/ui/opensnitch/dialogs/preferences/settings.py
+++ b/ui/opensnitch/dialogs/preferences/settings.py
@@ -9,6 +9,7 @@ ui_pb2, ui_pb2_grpc = proto.import_()
 from opensnitch.config import Config
 from opensnitch.utils import languages
 from opensnitch.database import Database
+from opensnitch.dialogs.prompt import constants as prompt_constants
 from opensnitch.dialogs.preferences import (
     utils,
 )
@@ -58,6 +59,15 @@ def load(win):
     win.dstPortCheck.setChecked(win.cfgMgr.getBool(win.cfgMgr.DEFAULT_POPUP_ADVANCED_DSTPORT))
     win.uidCheck.setChecked(win.cfgMgr.getBool(win.cfgMgr.DEFAULT_POPUP_ADVANCED_UID))
     win.checkSum.setChecked(win.cfgMgr.getBool(win.cfgMgr.DEFAULT_POPUP_ADVANCED_CHECKSUM))
+
+    default_full_cmds = ",".join(prompt_constants.FULL_COMMAND_BIN)
+    if win.cfgMgr.hasKey(win.cfgMgr.DEFAULT_POPUP_ADVANCED_FULL_COMMAND):
+        full_cmds = win.cfgMgr.getSettings(win.cfgMgr.DEFAULT_POPUP_ADVANCED_FULL_COMMAND)
+        if full_cmds is None:
+            full_cmds = ""
+    else:
+        full_cmds = default_full_cmds
+    win.fullCommandBin.setText(str(full_cmds))
 
     ## rules
     win.comboUIRules.blockSignals(True)
@@ -211,6 +221,7 @@ def save_ui_config(win):
         win.cfgMgr.setSettings(win.cfgMgr.DEFAULT_POPUP_ADVANCED_DSTPORT, bool(win.dstPortCheck.isChecked()))
         win.cfgMgr.setSettings(win.cfgMgr.DEFAULT_POPUP_ADVANCED_UID, bool(win.uidCheck.isChecked()))
         win.cfgMgr.setSettings(win.cfgMgr.DEFAULT_POPUP_ADVANCED_CHECKSUM, bool(win.checkSum.isChecked()))
+        win.cfgMgr.setSettings(win.cfgMgr.DEFAULT_POPUP_ADVANCED_FULL_COMMAND, win.fullCommandBin.text())
 
         win.cfgMgr.setSettings(win.cfgMgr.NOTIFICATIONS_ENABLED, bool(win.groupNotifs.isChecked()))
         win.cfgMgr.setSettings(win.cfgMgr.NOTIFICATIONS_TYPE,

--- a/ui/opensnitch/dialogs/prompt/constants.py
+++ b/ui/opensnitch/dialogs/prompt/constants.py
@@ -39,7 +39,7 @@ DURATION_12h     = "12h"
 
 APPIMAGE_PREFIX = "/tmp/.mount_"
 SNAP_PREFIX = "/snap"
-FULL_COMMAND_BIN = ["python", "curl", "wget", "node", "java"]
+FULL_COMMAND_BIN = ["python", "curl", "wget", "node", "java", "ssh"]
 
 # label displayed in the pop-up combo
 DURATION_session = QC.translate("popups", "until reboot")

--- a/ui/opensnitch/dialogs/prompt/constants.py
+++ b/ui/opensnitch/dialogs/prompt/constants.py
@@ -39,6 +39,7 @@ DURATION_12h     = "12h"
 
 APPIMAGE_PREFIX = "/tmp/.mount_"
 SNAP_PREFIX = "/snap"
+FULL_COMMAND_BIN = ["python", "curl", "wget", "node", "java"]
 
 # label displayed in the pop-up combo
 DURATION_session = QC.translate("popups", "until reboot")

--- a/ui/opensnitch/dialogs/prompt/utils.py
+++ b/ui/opensnitch/dialogs/prompt/utils.py
@@ -244,7 +244,7 @@ def set_default_target(combo, con, cfg, app_name, app_args):
             return
     # entire command as default target for "dangerous" commands
     # (e.g. curl, wget, node)
-    elif any(bin in connection_path.name for bin in constants.FULL_COMMAND_BIN):
+    elif any(connection_path.name.startswith(bin) for bin in constants.FULL_COMMAND_BIN):
         combo.setCurrentIndex(1)
         return
 

--- a/ui/opensnitch/dialogs/prompt/utils.py
+++ b/ui/opensnitch/dialogs/prompt/utils.py
@@ -228,6 +228,14 @@ def set_default_duration(cfg, durationCombo):
     else:
         durationCombo.setCurrentIndex(Config.DEFAULT_DURATION_IDX)
 
+def _get_full_command_bins(cfg):
+    if cfg.hasKey(cfg.DEFAULT_POPUP_ADVANCED_FULL_COMMAND):
+        full_cmds = cfg.getSettings(cfg.DEFAULT_POPUP_ADVANCED_FULL_COMMAND)
+        if full_cmds is not None:
+            return [x.strip() for x in full_cmds.split(",") if x.strip()]
+        return []
+    return constants.FULL_COMMAND_BIN
+
 def set_default_target(combo, con, cfg, app_name, app_args):
     # set appimage as default target if the process path starts with
     # /tmp/._mount
@@ -244,7 +252,7 @@ def set_default_target(combo, con, cfg, app_name, app_args):
             return
     # entire command as default target for "dangerous" commands
     # (e.g. curl, wget, node)
-    elif any(connection_path.name.startswith(bin) for bin in constants.FULL_COMMAND_BIN):
+    elif any(connection_path.name.startswith(bin) for bin in _get_full_command_bins(cfg)):
         combo.setCurrentIndex(1)
         return
 

--- a/ui/opensnitch/dialogs/prompt/utils.py
+++ b/ui/opensnitch/dialogs/prompt/utils.py
@@ -1,6 +1,7 @@
 from slugify import slugify
 import os
 import ipaddress
+from pathlib import Path
 
 from PyQt6.QtCore import QCoreApplication as QC
 
@@ -230,6 +231,7 @@ def set_default_duration(cfg, durationCombo):
 def set_default_target(combo, con, cfg, app_name, app_args):
     # set appimage as default target if the process path starts with
     # /tmp/._mount
+    connection_path = Path(con.process_path)
     if con.process_path.startswith(constants.APPIMAGE_PREFIX):
         idx = combo.findData(constants.FIELD_APPIMAGE)
         if idx != -1:
@@ -240,6 +242,11 @@ def set_default_target(combo, con, cfg, app_name, app_args):
         if idx != -1:
             combo.setCurrentIndex(idx)
             return
+    # entire command as default target for "dangerous" commands
+    # (e.g. curl, wget, node)
+    elif any(bin in connection_path.name for bin in constants.FULL_COMMAND_BIN):
+        combo.setCurrentIndex(1)
+        return
 
     saved_target = int(cfg.getSettings(cfg.DEFAULT_TARGET_KEY))
     # In order to respect user selection, the app_name and app_args must be

--- a/ui/opensnitch/res/preferences.ui
+++ b/ui/opensnitch/res/preferences.ui
@@ -546,6 +546,29 @@
               </property>
              </widget>
             </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="label_full_command">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Full command by default</string>
+              </property>
+              <property name="toolTip">
+               <string>Comma-separated list of commands that will be selected by default in the pop-up dialog.</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QLineEdit" name="fullCommandBin">
+              <property name="placeholderText">
+               <string>e.g. python, curl (leave empty to disable)</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </widget>
          </widget>

--- a/ui/opensnitch/res/preferences.ui
+++ b/ui/opensnitch/res/preferences.ui
@@ -555,17 +555,17 @@
                </sizepolicy>
               </property>
               <property name="text">
-               <string>Full command by default</string>
+               <string>Filter by full command by default</string>
               </property>
               <property name="toolTip">
-               <string>Comma-separated list of commands that will be selected by default in the pop-up dialog.</string>
+               <string>List of commands that will be selected to filter as "from this command line" by default in the pop-up dialog.&#10;The list should be comma-separated without spaces.&#10;It would match all commands that starts with a word in the list.</string>
               </property>
              </widget>
             </item>
             <item row="3" column="1">
              <widget class="QLineEdit" name="fullCommandBin">
               <property name="placeholderText">
-               <string>e.g. python, curl (leave empty to disable)</string>
+               <string>e.g. python,curl (leave empty to disable)</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
The default behavior when creating a rule using UI popup is matching by executables. This, however, is too broad for apps and scripts built with Python and node, or programs like `curl` and `wget`, because allowing `python3` to access a website means every scripts ran using `python3 script.py` will have access to that website.

This problem is [discussed previously](https://github.com/evilsocket/opensnitch/discussions/612#discussioncomment-2116878) and [included in Wiki](https://github.com/evilsocket/opensnitch/wiki/Rules-examples#filtering-python-scripts-applicable-to-java-and-others-interpreters), but is not widely known. This PR fixes that by setting the rule to match the entire command line by default, including all arguments, for such high-risk executable.

<img width="559" height="344" alt="Screenshot_20260124_235622" src="https://github.com/user-attachments/assets/3c496f82-9e96-4016-ac5d-adc1b163a227" />


Currently, the matched executables are `curl`, `wget`, `python`, `node`, `java`, `ssh`

Programs that fall into this bucket are much more common than people actually expect, even if they do not frequently program in those languages and/or use the command line. For example, this includes Lutris, Bottles, Anki, Claude Code, any `curl | bash` installation process, and Git over SSH.