### PR TITLE
fix(ui): null-check screen in PromptDialog

### DIFF
--- a/ui/opensnitch/dialogs/prompt/dialog.py
+++ b/ui/opensnitch/dialogs/prompt/dialog.py
@@ -250,8 +250,10 @@ class PromptDialog(QtWidgets.QDialog, uic.loadUiType(DIALOG_UI_PATH)[0]):
 
     def move_popup(self):
         popup_pos = self._cfg.getInt(self._cfg.DEFAULT_POPUP_POSITION)
-        point = self.screen().availableGeometry()
-        point = self.screen().virtualSiblingAt(QtGui.QCursor.pos()).availableGeometry()
+        screen = self.screen().virtualSiblingAt(QtGui.QCursor.pos())
+        if not screen:
+            return
+        point = screen.availableGeometry()
         if popup_pos == self._cfg.POPUP_TOP_RIGHT:
             self.move(point.topRight())
         elif popup_pos == self._cfg.POPUP_TOP_LEFT:


### PR DESCRIPTION
Fixes crash when pressing 'accept' with keyboard when mouse cursor is not on top of the popup.

> Traceback (most recent call last):
>   File "/path/to/opensnitch/dialogs/prompt/dialog.py", line 288, in _check_advanced_toggled
>     self.move_popup()
>     ~~~~~~~~~~~~~~~^^
>   File "/path/to/opensnitch/dialogs/prompt/dialog.py", line 254, in move_popup
>     point = self.screen().virtualSiblingAt(QtGui.QCursor.pos()).availableGeometry()
>             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> AttributeError: 'NoneType' object has no attribute 'availableGeometry'
> Fatal Python error: Aborted