### PR TITLE
persist firewall interception state across restarts

### DIFF
--- a/ui/opensnitch/config.py
+++ b/ui/opensnitch/config.py
@@ -110,6 +110,7 @@ class Config:
     DEFAULT_POPUP_ADVANCED_UID = "global/default_popup_advanced_uid"
     DEFAULT_POPUP_ADVANCED_CHECKSUM = "global/default_popup_advanced_checksum"
     DEFAULT_FW_INTERCEPTION_ENABLED = "global/interception_enabled"
+    DEFAULT_PERSIST_INTERCEPTION_STATE = "global/persist_interception_state"
     DEFAULT_SERVER_ADDR  = "global/server_address"
     DEFAULT_SERVER_MAX_MESSAGE_LENGTH  = "global/server_max_message_length"
     DEFAULT_SERVER_MAX_WORKERS = "global/max_workers"

--- a/ui/opensnitch/dialogs/events/dialog.py
+++ b/ui/opensnitch/dialogs/events/dialog.py
@@ -1000,7 +1000,8 @@ class StatsDialog(menus.MenusManager, menu_actions.MenuActions, views.ViewsManag
             return
 
         checked = self.startButton.isChecked()
-        Config.get().setSettings(Config.DEFAULT_FW_INTERCEPTION_ENABLED, checked)
+        if Config.get().getBool(Config.DEFAULT_PERSIST_INTERCEPTION_STATE, False):
+            Config.get().setSettings(Config.DEFAULT_FW_INTERCEPTION_ENABLED, checked)
         
         self.update_interception_status(checked)
         self._status_changed_trigger.emit(checked)

--- a/ui/opensnitch/dialogs/preferences/settings.py
+++ b/ui/opensnitch/dialogs/preferences/settings.py
@@ -51,6 +51,7 @@ def load(win):
     win.spinUITimeout.setValue(win.default_timeout)
     win.spinUITimeout.setEnabled(not win.disable_popups)
     win.popupsCheck.setChecked(win.disable_popups)
+    win.checkPersistInterception.setChecked(win.cfgMgr.getBool(win.cfgMgr.DEFAULT_PERSIST_INTERCEPTION_STATE, False))
 
     win.showAdvancedCheck.setChecked(win.cfgMgr.getBool(win.cfgMgr.DEFAULT_POPUP_ADVANCED))
     win.dstIPCheck.setChecked(win.cfgMgr.getBool(win.cfgMgr.DEFAULT_POPUP_ADVANCED_DSTIP))
@@ -199,6 +200,11 @@ def save_ui_config(win):
         win.cfgMgr.setSettings(win.cfgMgr.DEFAULT_TIMEOUT_KEY, win.spinUITimeout.value())
         win.cfgMgr.setSettings(win.cfgMgr.DEFAULT_DISABLE_POPUPS, bool(win.popupsCheck.isChecked()))
         win.cfgMgr.setSettings(win.cfgMgr.DEFAULT_POPUP_POSITION, int(win.comboUIDialogPos.currentIndex()))
+
+        persist_interception = bool(win.checkPersistInterception.isChecked())
+        win.cfgMgr.setSettings(win.cfgMgr.DEFAULT_PERSIST_INTERCEPTION_STATE, persist_interception)
+        if not persist_interception:
+            win.cfgMgr.setSettings(win.cfgMgr.DEFAULT_FW_INTERCEPTION_ENABLED, True)
 
         win.cfgMgr.setSettings(win.cfgMgr.DEFAULT_POPUP_ADVANCED, bool(win.showAdvancedCheck.isChecked()))
         win.cfgMgr.setSettings(win.cfgMgr.DEFAULT_POPUP_ADVANCED_DSTIP, bool(win.dstIPCheck.isChecked()))

--- a/ui/opensnitch/res/preferences.ui
+++ b/ui/opensnitch/res/preferences.ui
@@ -3104,8 +3104,21 @@ Use 0 to disable this feature.</string>
           </property>
          </spacer>
         </item>
+        <item row="19" column="0" colspan="2">
+         <widget class="QCheckBox" name="checkPersistInterception">
+          <property name="toolTip">
+           <string>Remember if the firewall was paused (interception disabled) and restore that state on restart</string>
+          </property>
+          <property name="text">
+           <string>Remember pause state across restarts</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="1">
-         <spacer name="horizontalSpacer_2">
+          <spacer name="horizontalSpacer_2">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>

--- a/ui/opensnitch/service.py
+++ b/ui/opensnitch/service.py
@@ -619,7 +619,8 @@ class UIService(ui_pb2_grpc.UIServicer, QtWidgets.QGraphicsObject):
             nid, noti = self._nodes.start_interception(_callback=self._notification_callback)
 
         self._fw_enabled = not enable
-        self._cfg.setSettings(self._cfg.DEFAULT_FW_INTERCEPTION_ENABLED, self._fw_enabled)
+        if self._cfg.getBool(self._cfg.DEFAULT_PERSIST_INTERCEPTION_STATE, False):
+            self._cfg.setSettings(self._cfg.DEFAULT_FW_INTERCEPTION_ENABLED, self._fw_enabled)
 
         self._stats_dialog._status_changed_trigger.emit(not enable)
 
@@ -850,14 +851,17 @@ class UIService(ui_pb2_grpc.UIServicer, QtWidgets.QGraphicsObject):
                 # if there're more than one node, we can't update the status
                 # based on the fw status, only if the daemon is running or not
                 if self._nodes.count() <= 1:
-                    saved_fw_enabled = self._cfg.getBool(self._cfg.DEFAULT_FW_INTERCEPTION_ENABLED, True)
-                    daemon_fw_running = kwargs['node_config'].isFirewallRunning
-                    if not saved_fw_enabled and daemon_fw_running:
-                        # user had paused before last shutdown, send disable to daemon
-                        self._nodes.stop_interception(_callback=self._notification_callback)
-                        self._update_fw_status(False)
+                    if self._cfg.getBool(self._cfg.DEFAULT_PERSIST_INTERCEPTION_STATE, False):
+                        saved_fw_enabled = self._cfg.getBool(self._cfg.DEFAULT_FW_INTERCEPTION_ENABLED, True)
+                        daemon_fw_running = kwargs['node_config'].isFirewallRunning
+                        if not saved_fw_enabled and daemon_fw_running:
+                            # user had paused before last shutdown, send disable to daemon
+                            self._nodes.stop_interception(_callback=self._notification_callback)
+                            self._update_fw_status(False)
+                        else:
+                            self._update_fw_status(daemon_fw_running)
                     else:
-                        self._update_fw_status(daemon_fw_running)
+                        self._update_fw_status(kwargs['node_config'].isFirewallRunning)
                 else:
                     self._update_fw_status(True)
         elif kwargs['action'] == self.ADD_RULE:


### PR DESCRIPTION
Hi,

When the OpenSnitch GUI is restarted, the pause state is always lost. The firewall starts as "running" regardless of whether the user had it paused before closing. Users who routinely pause the firewall on startup must manually re-pause every time.

This MR adds an opt-in preference to persist the firewall interception (pause) state across GUI restarts.

When enabled, the GUI remembers if the user had paused the firewall and automatically restores that state on next startup.

The new option "remember pause state across restarts"  was added under 'general' preferences and defaults to off to preserve the original behavior.

<img width="642" height="615" alt="Screenshot_2026-03-07_14-42-53" src="https://github.com/user-attachments/assets/c77c4928-cbb9-4ede-8f32-61d3fb3c25ef" />
