### PR TITLE
build: enable Protocol Buffers support for python annotations stub gen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.sock
 *.pyc
 *.profile
+
+.vscode/
+.idea/
+.DS_Store

--- a/proto/Makefile
+++ b/proto/Makefile
@@ -4,10 +4,11 @@ all: ../daemon/ui/protocol/ui.pb.go ../ui/opensnitch/ui_pb2.py
 	protoc -I. ui.proto --go_out=../daemon/ui/protocol/ --go-grpc_out=../daemon/ui/protocol/ --go_opt=paths=source_relative --go-grpc_opt=paths=source_relative
 
 ../ui/opensnitch/ui_pb2.py: ui.proto
-	python3 -m grpc_tools.protoc -I. --python_out=../ui/opensnitch/proto/ --grpc_python_out=../ui/opensnitch/proto/ ui.proto
+	python3 -m grpc_tools.protoc -I. --python_out=../ui/opensnitch/proto/ --pyi_out=../ui/opensnitch/proto/ --grpc_python_out=../ui/opensnitch/proto/ ui.proto
 
 clean:
 	@rm -rf ../daemon/ui/protocol/ui.pb.go
 	@rm -rf ../daemon/ui/protocol/ui_grpc.pb.go
 	@rm -rf ../ui/opensnitch/proto/ui_pb2.py
 	@rm -rf ../ui/opensnitch/proto/ui_pb2_grpc.py
+	@rm -rf ../ui/opensnitch/proto/ui_pb2.pyi


### PR DESCRIPTION
A small amend to proto/Makefile to enable python annotation stub file (.pyi) generation along the protobuf python bindings.
This help to leverage python lexing and type checking with known tools like `Ruff`, `ty`, `PyLance`, `Pyright`...