### PR TITLE
Fix rule filename not updating when action changes

### DIFF
--- a/ui/opensnitch/dialogs/ruleseditor/dialog.py
+++ b/ui/opensnitch/dialogs/ruleseditor/dialog.py
@@ -894,5 +894,13 @@ class RulesEditorDialog(QtWidgets.QDialog, uic.loadUiType(DIALOG_UI_PATH)[0]):
 
         if self.ruleNameEdit.text() == "":
             self.rule.name = slugify("%s %s %s" % (self.rule.action, self.rule.operator.type, self.rule.operator.data))
+        elif self._old_rule_name is not None:
+            # If the rule name was auto-generated (starts with an action prefix),
+            # and the action has changed, update the prefix to match the new action.
+            for old_action in (Config.ACTION_ALLOW, Config.ACTION_DENY, Config.ACTION_REJECT):
+                if self._old_rule_name.startswith(old_action + "-") and old_action != self.rule.action:
+                    self.rule.name = self.rule.action + self._old_rule_name[len(old_action):]
+                    self.ruleNameEdit.setText(self.rule.name)
+                    break
 
         return True, ""


### PR DESCRIPTION
## Summary

Fixes #1571

When editing a rule and changing its action (e.g. deny → allow), the JSON content updates correctly but the rule name (used as filename) retains the old action prefix, causing a mismatch.

**Example:** file `deny-always-firefox-esr.json` with content `{"action": "allow", ...}`

## Changes

In `ui/opensnitch/dialogs/ruleseditor/dialog.py`, added a check in `save_rule()`: when the rule name was auto-generated (starts with an action prefix like `allow-`, `deny-`, or `reject-`) and the action has changed, the prefix is updated to match the new action.

- Only affects auto-generated names (detected by `action-` prefix)
- Manually named rules are never modified
- Minimal change: 8 lines added

## How to test

1. Create a rule with auto-generated name (e.g. `deny-always-firefox-esr`)
2. Edit the rule, change action from Deny to Allow
3. Save
4. **Before fix:** filename stays `deny-always-firefox-esr.json`
5. **After fix:** filename updates to `allow-always-firefox-esr.json`