### PR TITLE
fix(ui): define viewport_row in onKeyDown to fix NameError crash

### DIFF
--- a/ui/opensnitch/customwidgets/generictableview.py
+++ b/ui/opensnitch/customwidgets/generictableview.py
@@ -741,6 +741,7 @@ class GenericTableView(QTableView):
 
         newValue = self.vScrollBar.value()
 
+        viewport_row = self.getViewportRowPos(curRow)
         offset = self.model().queryOffset
         limit = self.model().queryLimit
         if curRow >= self.maxRowsInViewport-2:


### PR DESCRIPTION
GenericTableView.onKeyDown() references `viewport_row` without defining it, causing a fatal NameError when pressing Down on a rules row. This mirrors the assignment from onKeyUp() so the limit-boundary check works.

Fixes #1592