### PR TITLE
daemon: fix data race in getClientConfig iterating rules during load

### DIFF
--- a/daemon/rule/loader.go
+++ b/daemon/rule/loader.go
@@ -65,11 +65,23 @@ func (l *Loader) NumRules() int {
 	return len(l.rules)
 }
 
-// GetAll returns the loaded rules.
+// GetAll returns a shallow snapshot of the loaded rules.
+//
+// The returned map is freshly allocated under the loader's read lock, so
+// the caller may safely call len() on it and range over it without holding
+// any lock and without racing against concurrent rule loading or replacement.
+// The *Rule values are still shared with the loader, but rules are replaced
+// wholesale (replaceUserRule writes a new pointer into the map) rather than
+// mutated in place, so the snapshot remains internally consistent for the
+// read-only use cases this method serves (e.g. the UI client-config dump).
 func (l *Loader) GetAll() map[string]*Rule {
 	l.RLock()
 	defer l.RUnlock()
-	return l.rules
+	snapshot := make(map[string]*Rule, len(l.rules))
+	for k, v := range l.rules {
+		snapshot[k] = v
+	}
+	return snapshot
 }
 
 // EnableChecksums enables checksums field for rules globally.

--- a/daemon/rule/loader_test.go
+++ b/daemon/rule/loader_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"math/rand"
 	"os"
+	"sync"
 	"testing"
 	"time"
 )
@@ -145,6 +146,90 @@ func TestRuleLoaderList(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRuleLoaderGetAllSnapshot exercises the slice/map race that used to
+// crash daemon startup with a large rule corpus: getClientConfig() called
+// GetAll() twice without holding any lock, so the map could grow between
+// len() and the for-range and the iterator would walk off the end of the
+// pre-sized slice (or panic with "concurrent map iteration and map write"
+// on bad luck).
+//
+// Verify GetAll() now returns a consistent snapshot: iterating it produces
+// exactly len(snapshot) entries, even while other goroutines are mutating
+// the underlying loader. Run with -race to also catch the underlying data
+// race on l.rules that this fix removes.
+func TestRuleLoaderGetAllSnapshot(t *testing.T) {
+	t.Parallel()
+
+	l, err := NewLoader(false)
+	if err != nil {
+		t.Fatal("NewLoader: ", err)
+	}
+
+	var emptyOps []Operator
+	op, _ := NewOperator(Simple, false, OpTrue, "", emptyOps)
+	if err := op.Compile(); err != nil {
+		t.Fatal("Compile: ", err)
+	}
+
+	// Pre-seed with some rules so iterations have something to do.
+	for i := 0; i < 100; i++ {
+		r := Create(fmt.Sprintf("seed-%04d", i), "", true, false, false, Allow, Restart, op)
+		if err := l.replaceUserRule(r); err != nil {
+			t.Fatal("seed replaceUserRule: ", err)
+		}
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Writers churn the map: add and remove rules continuously, exercising
+	// the same Lock()/Unlock() path as the daemon's loader during rule load.
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; ; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				name := fmt.Sprintf("churn-%d-%d", w, i)
+				r := Create(name, "", true, false, false, Allow, Restart, op)
+				_ = l.replaceUserRule(r)
+				if i&1 == 0 {
+					_ = l.Delete(name)
+				}
+			}
+		}(w)
+	}
+
+	// Readers do exactly what getClientConfig used to do incorrectly:
+	// observe len(), then iterate, and expect the two to agree.
+	for r := 0; r < 8; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				rules := l.GetAll()
+				n := len(rules)
+				count := 0
+				for range rules {
+					count++
+				}
+				if count != n {
+					t.Errorf("GetAll snapshot inconsistent: len=%d iterated=%d", n, count)
+					return
+				}
+			}
+		}()
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
 }
 
 func TestLiveReload(t *testing.T) {

--- a/daemon/ui/notifications.go
+++ b/daemon/ui/notifications.go
@@ -37,10 +37,14 @@ func (c *Client) getClientConfig() *protocol.ClientConfig {
 	nodeName := core.GetHostname()
 	nodeVersion := core.GetKernelVersion()
 	var ts time.Time
-	rulesTotal := len(c.rules.GetAll())
-	ruleList := make([]*protocol.Rule, rulesTotal)
+	// GetAll() returns a snapshot, so len() and the range below see a
+	// consistent view even if the loader is concurrently adding rules
+	// (this used to panic with "index out of range" on big rule sets, when
+	// the UI subscribed back during rules.Reload()).
+	rules := c.rules.GetAll()
+	ruleList := make([]*protocol.Rule, len(rules))
 	idx := 0
-	for _, r := range c.rules.GetAll() {
+	for _, r := range rules {
 		ruleList[idx] = r.Serialize()
 		idx++
 	}


### PR DESCRIPTION
## Bug

On a host with a large rule corpus (~2100 `*.json` files under `rules.Path`), the daemon panics during startup, reliably, every time the UI is already running:

```
panic: runtime error: index out of range [1002] with length 1002
goroutine 98 [running]:
github.com/evilsocket/opensnitch/daemon/ui.(*Client).getClientConfig(...)
        /root/build/opensnitch/daemon/ui/notifications.go:44 +0x33a
github.com/evilsocket/opensnitch/daemon/ui.(*Client).Subscribe(...)
        /root/build/opensnitch/daemon/ui/notifications.go:349 +0x85
created by github.com/evilsocket/opensnitch/daemon/ui.(*Client).onStatusChange in goroutine 30
        /root/build/opensnitch/daemon/ui/client.go:238 +0xa9
```

systemd `Restart=on-failure` then puts the daemon into a permanent crash loop (counter climbed to 8+ in our testing) — the firewall never comes up.

Indices in the panic line vary across restarts (1002, 1222, 1353, 1415, ...) — they're snapshots of partial rule loads.

## Root cause

`Loader.GetAll()` returns the loader's internal map *by reference* under an RLock that's released the instant the call returns:

```go
func (l *Loader) GetAll() map[string]*Rule {
    l.RLock()
    defer l.RUnlock()
    return l.rules
}
```

`getClientConfig()` then calls it twice — once for `len()` to size a slice, once to range over — without holding any lock:

```go
rulesTotal := len(c.rules.GetAll())
ruleList := make([]*protocol.Rule, rulesTotal)
idx := 0
for _, r := range c.rules.GetAll() {
    ruleList[idx] = r.Serialize()       // ← panic when idx == rulesTotal
    idx++
}
```

If the loader is still inserting entries between the two `GetAll()` calls — which is the common case at startup — the second call's map has grown, the iteration produces more entries than the pre-sized slice, and `ruleList[idx]` walks off the end.

The race is reachable because `reloadConfiguration` calls `c.Connect()` (which starts the connection poller) **before** `c.rules.Reload(newConfig.Rules.Path)`. With a small rule set, `Reload` finishes before the poller's first tick and there's no observable race. With a few thousand rules, the poller wins, the UI subscribes back, and `getClientConfig` runs in a separate goroutine while the loader is still synchronously parsing files.

`go test -race` catches the underlying data race too: `mapIterNext` (reader, post-`GetAll`) vs. `mapassign_faststr` in `replaceUserRule` (writer, holding `l.Lock()`).

## Fix

`daemon/rule/loader.go` — `GetAll()` now returns a shallow snapshot of the map under the read lock. Same return type, same `*Rule` pointers, just a freshly allocated map container so `len()` and iteration are guaranteed consistent for the caller, with no lock-discipline requirement.

`daemon/ui/notifications.go` — call `GetAll()` once into a local variable; size and iterate that one map. Minimal change to keep the diff focused.

`Loader.GetAll` has exactly one caller in the daemon today (`getClientConfig`), so the contract change is contained. Other callers (none) would have been broken by the previous behavior anyway, since iterating the returned map without holding any lock is unsafe.

The `*Rule` values in the snapshot are still shared with the loader, but rules are replaced wholesale (`replaceUserRule` writes a new pointer into the map) rather than mutated in place, so the snapshot remains internally consistent for the read-only use cases this method serves.

## Test

`TestRuleLoaderGetAllSnapshot` in `daemon/rule/loader_test.go` exercises the exact pattern that used to crash: writers churn the map via `replaceUserRule`/`Delete`, readers do the `len()`-then-iterate dance, and the test asserts the two counts agree. Verified that the test:

- **Fails** on master (without the fix) under `-race`: race detector flags `mapIterNext` vs. `mapassign_faststr`, plus the inconsistency check trips.
- **Passes** with the fix, both with and without `-race`.

## What this PR doesn't fix

- The nil-deref in `firewall.Serialize()` from the same `getClientConfig` site reported in #1380 — different root cause (firewall not initialized yet), worth its own change.
- The ordering bug in `reloadConfiguration` where `c.Connect()` runs before `c.rules.Reload()`. Fixing the ordering would make the race unreachable too, but is a broader surgery; fixing the locking contract at `GetAll` addresses the bug at the right layer.
