### PR TITLE
ui: fix undefined and possibly-unbound variable bugs

### DIFF
--- a/ui/opensnitch/customwidgets/generictableview.py
+++ b/ui/opensnitch/customwidgets/generictableview.py
@@ -739,6 +739,7 @@ class GenericTableView(QTableView):
             self._rows_selection.clear()
         self._rows_selection.add(curIdx.data())
 
+        viewport_row = self.getViewportRowPos(curRow)
         newValue = self.vScrollBar.value()
 
         offset = self.model().queryOffset

--- a/ui/opensnitch/customwidgets/main.py
+++ b/ui/opensnitch/customwidgets/main.py
@@ -236,6 +236,7 @@ class ConnectionsTableModel(QStandardItemModel):
         #sequential number of topmost/bottommost rows in viewport (numbering starts from the bottom with 1 not with 0)
         botRowNo = max(1, self.totalRowCount - (value + maxRowsInViewport-1))
         topRowNo = min(botRowNo + maxRowsInViewport-1, self.totalRowCount)
+        offsetInRange = 0
 
         if not self.isQueryFilter:
             part1, part2 = self.origQueryStr.split('ORDER')

--- a/ui/opensnitch/database/__init__.py
+++ b/ui/opensnitch/database/__init__.py
@@ -450,8 +450,8 @@ class Database:
 
     def _insert(self, query_str, columns):
         with self._lock:
+            q = None
             try:
-
                 q = QSqlQuery(self.db)
                 q.prepare(query_str)
                 for idx, v in enumerate(columns):
@@ -465,7 +465,8 @@ class Database:
             except Exception as e:
                 self.logger.warning("_insert exception: %s", repr(e))
             finally:
-                q.finish()
+                if q is not None:
+                    q.finish()
 
         return False
 
@@ -497,6 +498,7 @@ class Database:
         qstr = "UPDATE " + action_on_conflict + " " + table + " SET " + fields
         if condition is not None:
             qstr += " WHERE " + condition
+        q = None
         try:
             with self._lock:
                 q = QSqlQuery(qstr, self.db)
@@ -510,11 +512,13 @@ class Database:
         except Exception as e:
             self.logger.warning("update() exception: %s", repr(e))
         finally:
-            q.finish()
+            if q is not None:
+                q.finish()
 
     def _insert_batch(self, query_str, fields, values):
         result=True
         with self._lock:
+            q = None
             try:
                 q = QSqlQuery(self.db)
                 q.prepare(query_str)
@@ -530,7 +534,8 @@ class Database:
             except Exception as e:
                 self.logger.warning("_insert_batch() exception: %s", repr(e))
             finally:
-                q.finish()
+                if q is not None:
+                    q.finish()
 
         return result
 

--- a/ui/opensnitch/desktop_parser.py
+++ b/ui/opensnitch/desktop_parser.py
@@ -6,11 +6,10 @@ import os
 import re
 import locale
 
-is_pyinotify_available = True
 try:
     import pyinotify
 except Exception as e:
-    is_pyinotify_available = False
+    pyinotify = None
     print("Error importing pyinotify:", e)
 
 DESKTOP_PATHS = tuple([
@@ -47,7 +46,7 @@ class LinuxDesktopParser(threading.Thread):
             for desktop_file in glob.glob(os.path.join(desktop_path, '*.desktop')):
                 self._parse_desktop_file(desktop_file)
 
-        if is_pyinotify_available:
+        if pyinotify is not None:
             self.start()
 
     def get_locale(self):
@@ -179,6 +178,8 @@ class LinuxDesktopParser(threading.Thread):
         return self.apps.get(def_name, (def_name, default_icon, None))
 
     def run(self):
+        if pyinotify is None:
+            return
         self.running = True
         wm = pyinotify.WatchManager()
         notifier = pyinotify.Notifier(wm)

--- a/ui/opensnitch/dialogs/events/menus.py
+++ b/ui/opensnitch/dialogs/events/menus.py
@@ -155,6 +155,7 @@ class MenusManager(views.ViewsManager):
             rule_action = model.index(selection[0].row(), FirewallTableModel.COL_ACTION).data()
             rule_action = rule_action.lower()
 
+            _action_accept = _action_drop = _action_reject = _action_return = None
             nodes_menu = []
             if self.nodes_count() > 1:
                 nodes_menu.append(

--- a/ui/opensnitch/dialogs/events/queries.py
+++ b/ui/opensnitch/dialogs/events/queries.py
@@ -244,6 +244,8 @@ class Queries:
 
     def get_indetail_filter(self, indetail_view, lastQuery, text, advanced_filter):
         """builds the query when a tab is in the detail view."""
+        base_query = []
+        qstr = ""
         try:
             cur_idx = self.win.get_current_view_idx()
             base_query = lastQuery.split("GROUP BY")

--- a/ui/opensnitch/dialogs/events/views.py
+++ b/ui/opensnitch/dialogs/events/views.py
@@ -526,8 +526,8 @@ class ViewsManager(config.ConfigManager, nodes.NodesManager, base.EventsBase):
                 QtWidgets.QMessageBox.Icon.Warning)
 
     def on_cmd_back_clicked(self, idx):
+        cur_idx = self.get_current_view_idx()
         try:
-            cur_idx = self.get_current_view_idx()
             self.set_in_detail_view(cur_idx, False)
 
             self.set_active_widgets(cur_idx, False)

--- a/ui/opensnitch/dialogs/prompt/dialog.py
+++ b/ui/opensnitch/dialogs/prompt/dialog.py
@@ -441,6 +441,7 @@ class PromptDialog(QtWidgets.QDialog, uic.loadUiType(DIALOG_UI_PATH)[0]):
         self.set_message_style('')
         self.labelChecksumStatus.setText('')
         is_valid = True
+        expected = ""
         checksums = con.process_checksums
         expected_list = []
 

--- a/ui/opensnitch/firewall/chains.py
+++ b/ui/opensnitch/firewall/chains.py
@@ -16,22 +16,6 @@ class Chains():
 
     def get_node_chains(self, addr):
         node = self._nodes.get_node(addr)
-        if node == None:
-            return rules
-        if not 'firewall' in node:
-            return rules
-
-        chains = []
-        for c in node['firewall'].SystemRules:
-            # Chains node does not exist on <= v1.5.x
-            try:
-                chains.append(c.Chains)
-            except Exception:
-                pass
-        return chains
-
-    def get_node_chains(self, addr):
-        node = self._nodes.get_node(addr)
         if node is None:
             return []
         if not 'firewall' in node:
@@ -65,10 +49,7 @@ class Chains():
                 # specify ipv4 OR/AND ipv6? some systems have ipv6 disabled
                 if c.Hook.lower() == hook and c.Type.lower() == _type and c.Family.lower() == family:
                     fwcfg.SystemRules[sdx].Chains[cdx].Policy = policy
-
-                    if wantedHook == Fw.Hooks.INPUT.value and wantedPolicy == Fw.Policy.DROP.value:
-                        fwcfg.SystemRules[sdx].Chains[cdx].Rules.extend([rule.Rules[0]])
-                        self._nodes.add_fw_config(node_addr, fwcfg)
+                    self._nodes.add_fw_config(node_addr, fwcfg)
                     return True
         return False
 

--- a/ui/opensnitch/plugins/__init__.py
+++ b/ui/opensnitch/plugins/__init__.py
@@ -30,10 +30,6 @@ class PluginSignal(QtCore.QObject):
     def disconnect(self, callback):
         self.signal.disconnect(callback)
 
-    #@QtCore.pyqtSlot(dict)
-    def cb_signal(self, args):
-        self.signal.disconnect(callback)
-
 class PluginsList():
     """plugins store. Whenever a plugin is instantiated, it's added to the
     plugin list automatically

--- a/ui/opensnitch/plugins/downloader/downloader.py
+++ b/ui/opensnitch/plugins/downloader/downloader.py
@@ -100,6 +100,7 @@ class Downloader(PluginBase):
                     interval = ((float(config['interval']) * 60) * 60) * 60
                 else:
                     logger.warning("compile() unknown time format '{0}'".format(config['units']))
+                    continue
 
                 self.scheduled_tasks[config['name']] = self.new_timer(interval, config)
         except Exception as e:

--- a/ui/opensnitch/plugins/virustotal/virustotal.py
+++ b/ui/opensnitch/plugins/virustotal/virustotal.py
@@ -366,6 +366,7 @@ class Virustotal(PluginBase):
 
         error = (errmsg is not None)
         malicious = False
+        verdict = None
         labelStyle = "color: {0}".format(config['benign-label-style'])
         try:
             if error:

--- a/ui/opensnitch/rules.py
+++ b/ui/opensnitch/rules.py
@@ -238,6 +238,7 @@ class Rules(QObject):
         """Gets the rule from the DB and writes it out to a directory.
         A new directory per node will be created.
         """
+        rulesdir = outdir
         try:
             records = self._db.get_rule(rule_name, node)
             if records.next() == False:

--- a/ui/opensnitch/service.py
+++ b/ui/opensnitch/service.py
@@ -481,8 +481,8 @@ class UIService(ui_pb2_grpc.UIServicer, QtWidgets.QGraphicsObject):
                 self._stats_dialog.activateWindow()
 
         has_ntfs, ntf_type = self._has_desktop_notifications()
+        timeout = self._cfg.getInt(Config.DEFAULT_TIMEOUT_KEY, 15)
         if has_ntfs:
-            timeout = self._cfg.getInt(Config.DEFAULT_TIMEOUT_KEY, 15)
             try:
                 self.show_systray_msg(
                     title,
@@ -636,6 +636,8 @@ class UIService(ui_pb2_grpc.UIServicer, QtWidgets.QGraphicsObject):
         return False
 
     def _build_missed_rule_msg(self, conn, rule, node, hostname):
+        _title = ""
+        tmpl = ""
         try:
             _title = conn.process_path
             if _title == "":

--- a/ui/opensnitch/utils/__init__.py
+++ b/ui/opensnitch/utils/__init__.py
@@ -443,6 +443,7 @@ class Icons():
     def get_by_appname(app_icon):
         """return the pixmap of an application.
         """
+        pixmap = None
         try:
             icon = QtGui.QIcon().fromTheme(app_icon)
             pixmap = icon.pixmap(icon.actualSize(QtCore.QSize(48, 48)))


### PR DESCRIPTION
Fixes a set of `NameError`-class bugs in the Python UI:

- Undefined names (guaranteed crash): `viewport_row`, `set_policy` (`wantedHook`/`wantedPolicy`/`rule`), a duplicate `get_node_chains` returning an undefined `rules`, and a stale `cb_signal`.
- Used-before-assignment on some paths: `timeout` in `_show_systray_message`; `_action_*` in the firewall context menu; `interval` for unknown downloader units; `q` in DB `finally` cleanups; `base_query`/`qstr`, `cur_idx`, `rulesdir`, `tmpl`/`_title`, `pixmap`.
- `pyinotify`: guard usage on import availability via an identity check.