### PR TITLE
fix "font rendering" due to 000-allow-localhost6.json 's description

### DIFF
--- a/daemon/data/rules/000-allow-localhost6.json
+++ b/daemon/data/rules/000-allow-localhost6.json
@@ -2,7 +2,7 @@
   "created": "2025-04-09T23:17:39-06:00",
   "updated": "2025-04-09T23:17:39-06:00",
   "name": "000-allow-localhost6",
-  "description": "Allow connections to localhost. More information:\n\nhttps://github.com/evilsocket/opensnitch/wiki/Rules#localhost-connections",
+  "description": "Allow connections to localhost. More information:\nhttps://github.com/evilsocket/opensnitch/wiki/Rules#localhost-connections",
   "action": "allow",
   "duration": "always",
   "operator": {


### PR DESCRIPTION
the description for this rule, in the UI, vertically centers the 3 lines(2 text and one empty newline in the middle) thus showing only a few pixels of the first and last lines' text as the description for this rule making you believe there's something wrong with the font rendering.


before:
<img width="1276" height="752" alt="before" src="https://github.com/user-attachments/assets/11db26e1-c844-4452-9249-88641827779c" />

after:
 Removing one `\n` allows the two text lines to remain visible enough to be readable.
<img width="1277" height="753" alt="after" src="https://github.com/user-attachments/assets/a3454a11-adff-44bf-9ed2-7e0ba624129c" />
