### PR TITLE
fix: remove trailing spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: protocol opensnitch_daemon gui
 
 install:
-	@cd daemon && make install	
+	@cd daemon && make install
 	@cd ui && make install
 
 protocol:
@@ -23,20 +23,20 @@ run:
 	opensnitch-ui --socket unix:///tmp/osui.sock &
 	./daemon/opensnitchd -rules-path /etc/opensnitchd/rules -ui-socket unix:///tmp/osui.sock -cpu-profile cpu.profile -mem-profile mem.profile
 
-test: 
-	clear 
+test:
+	clear
 	make clean
 	clear
 	mkdir -p rules
-	make 
+	make
 	clear
 	make run
 
 adblocker:
-	clear 
+	clear
 	make clean
 	clear
-	make 
+	make
 	clear
 	python make_ads_rules.py
 	clear

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -1,4 +1,4 @@
-#SRC contains all *.go *.c *.h files in daemon/ and its subfolders 
+#SRC contains all *.go *.c *.h files in daemon/ and its subfolders
 SRC := $(shell find . -type f -name '*.go' -o -name '*.h' -o -name '*.c')
 PREFIX?=/usr/local
 
@@ -23,7 +23,7 @@ install:
 
 opensnitchd: $(SRC)
 	@go get
-	@go build -o opensnitchd . 
+	@go build -o opensnitchd .
 
 clean:
 	@rm -rf opensnitchd

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -9,7 +9,7 @@ opensnitch/resources_rc.py: translations deps
 
 translations:
 	@cd i18n ; make
-	
+
 deps:
 	@pip3 install -r requirements.txt
 

--- a/ui/i18n/Makefile
+++ b/ui/i18n/Makefile
@@ -1,9 +1,9 @@
 include ./opensnitch_i18n.pro
 
-#TSFILES contains all *.ts files in locales/ and its subfolders 
+#TSFILES contains all *.ts files in locales/ and its subfolders
 #TSFILES := $(shell find locales/ -type f -name '*.ts')
 
-#QMFILES contains all *.qm files in locales/ and its subfolders 
+#QMFILES contains all *.qm files in locales/ and its subfolders
 QMFILES := $(shell find locales/ -type f -name '*.qm')
 #if QMFILES is empty, we set it to phony target to run unconditionally
 ifeq ($(QMFILES),)
@@ -12,7 +12,7 @@ endif
 
 all: $(TSFILES) $(QMFILES)
 
-#if any file from SOURCES or FORMS is older than any file from $(TSFILES)  
+#if any file from SOURCES or FORMS is older than any file from $(TSFILES)
 #or if opensnitch_i18n.pro was manually modified
 
 # pylupdate6 does not support parsing .pro files anymore


### PR DESCRIPTION
The PR removes trailing spaces from ends of some lines in different Makefiles, since they can lead to hidden errors.