### PR TITLE
ui: add navigation between tabs

### DIFF
--- a/ui/opensnitch/dialogs/events/dialog.py
+++ b/ui/opensnitch/dialogs/events/dialog.py
@@ -1349,9 +1349,17 @@ class StatsDialog(menus.MenusManager, menu_actions.MenuActions, views.ViewsManag
     def hideEvent(self, e):
         self._save_settings()
 
-    # https://gis.stackexchange.com/questions/86398/how-to-disable-the-escape-key-for-a-dialog
     def keyPressEvent(self, event):
+        if event.matches(QtGui.QKeySequence.StandardKey.NextChild):
+            next_idx = (self.tabWidget.currentIndex() + 1) % self.tabWidget.count()
+            self.tabWidget.setCurrentIndex(next_idx)
+            event.accept()
+        if event.matches(QtGui.QKeySequence.StandardKey.PreviousChild):
+            prev_idx = (self.tabWidget.currentIndex() - 1) % self.tabWidget.count()
+            self.tabWidget.setCurrentIndex(prev_idx)
+            event.accept()
         if event.matches(QtGui.QKeySequence.StandardKey.Find) or event.key() == QtCore.Qt.Key.Key_Slash:
             self.get_search_widget().setFocus()
+        # https://gis.stackexchange.com/questions/86398/how-to-disable-the-escape-key-for-a-dialog
         if not event.key() == QtCore.Qt.Key.Key_Escape:
             super(StatsDialog, self).keyPressEvent(event)


### PR DESCRIPTION
In continuation to the proposal #1624 this is a PR with a possible implementation of the functionality.

This PR adds the possibility to navigate between GUI tabs with "Ctrl+Tab" and "Ctrl+Shift+Tab".

**Note** The only issue right now is when the GUI loses focus from tabs (i.e. focuses on a table in a tab) the shortcuts start navigating through the data of the focused table, not the tabs. If the functionality looks appropriate and will be accepted, I will find the solution for this issue (there is the possibility to get the focus back with esc or something like this.)