### PR TITLE
ui: Fix systray message crash when desktop notifications are unavailable

### DIFF
--- a/ui/opensnitch/service.py
+++ b/ui/opensnitch/service.py
@@ -482,9 +482,9 @@ class UIService(ui_pb2_grpc.UIServicer, QtWidgets.QGraphicsObject):
                 #self._stats_dialog.raise()
                 self._stats_dialog.activateWindow()
 
+        timeout = self._cfg.getInt(Config.DEFAULT_TIMEOUT_KEY, 15)
         has_ntfs, ntf_type = self._has_desktop_notifications()
         if has_ntfs:
-            timeout = self._cfg.getInt(Config.DEFAULT_TIMEOUT_KEY, 15)
             try:
                 self.show_systray_msg(
                     title,

--- a/ui/tests/test_service.py
+++ b/ui/tests/test_service.py
@@ -1,0 +1,39 @@
+from PyQt6 import QtWidgets
+
+from opensnitch.config import Config
+from opensnitch.service import UIService
+
+
+class FakeConfig:
+    def __init__(self, timeout):
+        self.timeout = timeout
+
+    def getInt(self, key, default=None):
+        assert key == Config.DEFAULT_TIMEOUT_KEY
+        return self.timeout
+
+
+class FakeTray:
+    def __init__(self):
+        self.messages = []
+
+    def showMessage(self, title, body, icon, timeout):
+        self.messages.append((title, body, icon, timeout))
+
+
+class FakeService:
+    def __init__(self, timeout):
+        self._cfg = FakeConfig(timeout)
+        self._tray = FakeTray()
+
+    def _has_desktop_notifications(self):
+        return False, Config.NOTIFICATION_TYPE_QT
+
+
+def test_show_systray_message_without_desktop_notifications_uses_config_timeout():
+    service = FakeService(timeout=7)
+    icon = QtWidgets.QSystemTrayIcon.MessageIcon.Information
+
+    UIService._show_systray_message(service, "title", "body", icon, urgency=0)
+
+    assert service._tray.messages == [("title", "body", icon, 7000)]


### PR DESCRIPTION
Fixes #1613 

  ## Summary

  Fixes an `UnboundLocalError` in `_show_systray_message()` when desktop notifications are unavailable.

  `timeout` was only assigned inside the `has_ntfs` branch, but the fallback tray notification path also uses it. On
  environments such as GNOME Shell without AppIndicator/systray support, `_has_desktop_notifications()` can return
  `False`, causing the UI to crash before showing the message.

  ## Changes

  - Move the default timeout lookup before the desktop notification backend branch.
  - Add a regression test for the no-desktop-notifications fallback path.